### PR TITLE
feat: replace Bink video with FFmpeg/MP4 FMV pipeline

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,31 +1,59 @@
-cmake_minimum_required (VERSION 3.10)
-# select GLVND versus legacy OpenGL libraries
+cmake_minimum_required(VERSION 3.10)
+# Select GLVND versus legacy OpenGL libraries
 cmake_policy(SET CMP0072 NEW) # cmake --help-policy CMP0072
 project(mc2)
 
 include(CMakeToolsHelpers OPTIONAL)
 
+# Set C++ standard to C++17
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 # Set a default build type for single-configuration
-# CMake generators if no build type is set.
 #IF(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
 #   SET(CMAKE_BUILD_TYPE RelWithDebInfo)
 #ENDIF(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
 
-message("CMAKE library architecture: ${CMAKE_LIBRARY_ARCHITECTURE}")
-
+# Define third-party paths
+set(THIRDPARTY_DIR "${CMAKE_CURRENT_SOURCE_DIR}/3rdparty")
+set(THIRDPARTY_INCLUDE_DIRS "${THIRDPARTY_DIR}/include")
 if("${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
-	message(STATUS "Target is 64 bits")
-	set_property(GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS TRUE)
-else("${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
-	message(STATUS "Target is 32 bits")
-endif("${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
+    message(STATUS "Target is 64 bits")
+    set_property(GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS TRUE)
+    set(THIRDPARTY_LIB_DIR "${THIRDPARTY_DIR}/lib/x64")
+else()
+    message(STATUS "Target is 32 bits")
+    set(THIRDPARTY_LIB_DIR "${THIRDPARTY_DIR}/lib/x86")
+endif()
+
+# Add third-party include and library directories
+include_directories(${THIRDPARTY_INCLUDE_DIRS})
+link_directories(${THIRDPARTY_LIB_DIR})
+
+# FFmpeg paths (already specific to FFmpeg)
+include_directories("${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/ffmpeg/include")
+set(FFMPEG_DIR "${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/ffmpeg")
+include_directories("${FFMPEG_DIR}/include")
+link_directories("${FFMPEG_DIR}/lib")
+
+set(FFMPEG_LIBS
+    avcodec
+    avformat
+    avutil
+    swscale
+    swresample
+)
+
+message("CMAKE library architecture: ${CMAKE_LIBRARY_ARCHITECTURE}")
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS "ON")
 
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_PREFIX_PATH}/cmake)
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/sdl2)
-# may have to help find_package bydetting path to FindSDL2.cmake
-#set(SDL2_DIR "${CMAKE_PREFIX_PATH}/cmake")
+# Set CMAKE_PREFIX_PATH to include the 3rdparty directory
+list(APPEND CMAKE_PREFIX_PATH "${THIRDPARTY_DIR}")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/sdl2")
+
+# Set SDL2_DIR to the directory containing SDL2Config.cmake
+set(SDL2_DIR "${THIRDPARTY_DIR}/cmake")
 
 if(NOT MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x -ggdb")
@@ -34,34 +62,59 @@ endif()
 # -Wno-unused-local-typedefs - to disable "typedef was ignored on this declaration"
 
 if(MSVC)
-	add_definitions(-DPLATFORM_WINDOWS)
-	add_definitions(-D_CRT_SECURE_NO_WARNINGS)
-	message("Compiling on M$ Windows")
+    add_definitions(-DPLATFORM_WINDOWS)
+    add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+    message("Compiling on M$ Windows")
 endif()
-
-# to support windows sln file generator as well
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -D_ARMOR -D_DEBUG -DBUGLOG -DLAB_ONLY")
-#set(CMAKE_CXX_FLAGS_RELWITHDEBINFO" ${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -DSOME_STUFF")
-if(MSVC)
-    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MTd /MP")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
-    #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP -DWINDOWS_IGNORE_PACKING_MISMATCH")
-endif()
-
 
 add_definitions(-DUSE_ASSEMBLER_CODE=0)
 add_definitions(-DLINUX_BUILD)
 
-find_package(SDL2 REQUIRED CONFIG REQUIRED COMPONENTS SDL2)
-find_package(SDL2 REQUIRED CONFIG REQUIRED COMPONENTS SDL2main)
+# Find packages
+find_package(SDL2 REQUIRED CONFIG COMPONENTS SDL2)
+find_package(SDL2 REQUIRED CONFIG COMPONENTS SDL2main)
 find_package(SDL2_mixer REQUIRED)
-#required by text_tool
 find_package(SDL2_ttf REQUIRED)
-find_package(GLEW REQUIRED)
-find_package(OpenGL REQUIRED)
-find_package(ZLIB REQUIRED)
 
-message("Found SDL2 package ${SDL2_LIBRARIES}" )
+# GLEW
+find_package(GLEW)
+if(NOT GLEW_FOUND)
+    message(STATUS "GLEW not found by find_package, setting manually")
+    set(GLEW_FOUND TRUE)
+    set(GLEW_INCLUDE_DIRS "${THIRDPARTY_INCLUDE_DIRS}")
+    set(GLEW_LIBRARIES "${THIRDPARTY_LIB_DIR}/glew32.lib")
+    # Create imported target GLEW::GLEW
+    add_library(GLEW::GLEW UNKNOWN IMPORTED)
+    set_target_properties(GLEW::GLEW PROPERTIES
+        IMPORTED_LOCATION "${GLEW_LIBRARIES}"
+        INTERFACE_INCLUDE_DIRECTORIES "${GLEW_INCLUDE_DIRS}"
+    )
+endif()
+message(STATUS "GLEW_FOUND: ${GLEW_FOUND}")
+message(STATUS "GLEW_INCLUDE_DIRS: ${GLEW_INCLUDE_DIRS}")
+message(STATUS "GLEW_LIBRARIES: ${GLEW_LIBRARIES}")
+
+find_package(OpenGL REQUIRED)
+
+# Zlib
+find_package(ZLIB)
+if(NOT ZLIB_FOUND)
+    message(STATUS "Zlib not found by find_package, setting manually")
+    set(ZLIB_FOUND TRUE)
+    set(ZLIB_INCLUDE_DIRS "${THIRDPARTY_INCLUDE_DIRS}")
+    set(ZLIB_LIBRARIES "${THIRDPARTY_LIB_DIR}/zlib.lib")
+    # Create imported target ZLIB::ZLIB
+    add_library(ZLIB::ZLIB UNKNOWN IMPORTED)
+    set_target_properties(ZLIB::ZLIB PROPERTIES
+        IMPORTED_LOCATION "${ZLIB_LIBRARIES}"
+        INTERFACE_INCLUDE_DIRECTORIES "${ZLIB_INCLUDE_DIRS}"
+    )
+endif()
+message(STATUS "ZLIB_FOUND: ${ZLIB_FOUND}")
+message(STATUS "ZLIB_INCLUDE_DIRS: ${ZLIB_INCLUDE_DIRS}")
+message(STATUS "ZLIB_LIBRARIES: ${ZLIB_LIBRARIES}")
+
+message("Found SDL2 package ${SDL2_LIBRARIES}")
 message("SDL2 prefix: ${SDL2_PREFIX}")
 message("OPENGL library found in ${OPENGL}")
 message("GLEW library found in ${GLEW}")
@@ -70,12 +123,10 @@ message("Zlib library found in ${ZLIB}")
 message("OpenGL library linking: ${OPENGL_gl_LIBRARY}")
 message("OpenGL library include: ${OPENGL_INCLUDE_DIR}")
 
-
 get_filename_component(COM_PATH1 "./GameOS/include" ABSOLUTE)
 get_filename_component(COM_PATH2 "./GameOS/gameos" ABSOLUTE)
 
-set(COMMON_INCLUDE_DIRS  ${COM_PATH1} ${COM_PATH2})
-set(THIRDPARTY_INCLUDE_DIRS "${CMAKE_PREFIX_PATH}/include")
+set(COMMON_INCLUDE_DIRS ${COM_PATH1} ${COM_PATH2})
 
 add_subdirectory("./mclib/" "./out/mclib")
 add_subdirectory("./mclib/mlr" "./out/mclib/mlr")
@@ -105,6 +156,8 @@ set(SOURCES
     "code/mover.cpp"
     "code/objmgr.cpp"
     "code/objtype.cpp"
+    "code/mp4player.cpp"
+    "code/mc2movie.cpp"
     "code/tacordr.cpp"
     "code/team.cpp"
     "code/terrobj.cpp"
@@ -175,26 +228,80 @@ set(SOURCES
     "code/chatwindow.cpp"
     "code/mpstats.cpp"
     "code/multplyr.cpp"
-    "code/mc2movie.cpp"
-    )
-
+)
 
 include_directories(${COMMON_INCLUDE_DIRS} "./mclib" "./gui" "./code" "./netlib")
 include_directories(${THIRDPARTY_INCLUDE_DIRS})
 
 if(NOT WIN32)
-	set(ADDITIONAL_LIBS dl)
-	message("Not win32 system")
+    set(ADDITIONAL_LIBS dl)
+    message("Not win32 system")
 else()
-	# winmm for timeGetTime, maybe switch to GetTickCount to remove this dependency
-	set(ADDITIONAL_LIBS winmm)
+    # winmm for timeGetTime, maybe switch to GetTickCount to remove this dependency
+    set(ADDITIONAL_LIBS winmm)
 endif()
 
-
 add_executable(mc2 ${SOURCES} ${MAIN_SRC})
-target_link_libraries(mc2 mclib gosfx mlr stuff gui gameos gameos_main windows ZLIB::ZLIB ${SDL2_LIBRARIES} GLEW::GLEW SDL2_mixer::SDL2_mixer ${ADDITIONAL_LIBS} OpenGL::GL)
+target_link_libraries(
+    mc2 
+    mclib 
+    gosfx 
+    mlr 
+    stuff 
+    gui 
+    gameos 
+    gameos_main 
+    windows 
+    ZLIB::ZLIB 
+    ${SDL2_LIBRARIES} 
+    GLEW::GLEW 
+    SDL2_mixer::SDL2_mixer 
+    ${ADDITIONAL_LIBS} 
+    OpenGL::GL 
+    ${FFMPEG_LIBS}
+    avcodec
+    avformat
+    avutil
+    swscale
+    swresample
+)
+
+# Clean standalone MP4 player — NO game engine dependencies
+add_executable(clean_mp4_player
+    code/clean_mp4_player.cpp
+)
+
+target_include_directories(clean_mp4_player PRIVATE
+    ${THIRDPARTY_INCLUDE_DIRS}
+)
+
+target_link_libraries(clean_mp4_player
+    ${SDL2_LIBRARIES}
+    GLEW::GLEW
+    OpenGL::GL
+    ${FFMPEG_LIBS}
+)
 
 add_subdirectory("./res" "./out/res")
 add_subdirectory("./data_tools" "./out/data_tools")
 add_subdirectory("./text_tool" "./out/text_tool")
 add_subdirectory("./Viewer" "./out/Viewer")
+
+# Copy runtime DLLs
+add_custom_command(TARGET mc2 POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+    "${THIRDPARTY_LIB_DIR}/glew32.dll"
+    $<TARGET_FILE_DIR:mc2>)
+add_custom_command(TARGET mc2 POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+    "${THIRDPARTY_LIB_DIR}/zlib1.dll"
+    $<TARGET_FILE_DIR:mc2>)
+
+# Copy mc2.exe to full_game directory after build so the user can launch
+# the freshly built binary directly from full_game/ without a manual copy.
+add_custom_command(TARGET mc2 POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+    $<TARGET_FILE:mc2>
+    "${CMAKE_SOURCE_DIR}/full_game/mc2.exe"
+    COMMENT "Copying mc2.exe to full_game/"
+)

--- a/GameOS/gameos/gameos_graphics.cpp
+++ b/GameOS/gameos/gameos_graphics.cpp
@@ -2407,6 +2407,12 @@ void __stdcall gos_UnLockTexture( DWORD Handle )
     //gosASSERT(0 && "Not implemented");
 }
 
+uint32_t __stdcall gos_GetTextureGLId( DWORD Handle )
+{
+    gosTexture* tex = g_gos_renderer->getTexture( Handle );
+    return tex ? tex->getTextureId() : 0;
+}
+
 void __stdcall gos_PushRenderStates()
 {
     gosASSERT(g_gos_renderer);

--- a/GameOS/include/gameos.hpp
+++ b/GameOS/include/gameos.hpp
@@ -2842,6 +2842,17 @@ void __stdcall gos_LockTexture( DWORD Handle, DWORD MipMapSize, bool ReadOnly, T
 void __stdcall gos_UnLockTexture( DWORD Handle );
 
 //
+// Returns the underlying GL texture id for Handle, or 0 if invalid.
+// Intended for fast-path per-frame uploads (e.g. video) using
+// glBindTexture + glTexSubImage2D, bypassing gos_LockTexture's
+// readback + byte-swap path. Uses uint32_t rather than GLuint to
+// avoid dragging a GL header into this public interface; GL spec
+// guarantees GLuint is a 32-bit unsigned int, so callers can pass
+// the return value directly to glBindTexture.
+//
+uint32_t __stdcall gos_GetTextureGLId( DWORD Handle );
+
+//
 // Converts from 32bpp source to subrect of n-bpp dest, bypassing intermediate 32bpp buffer
 //
 void __stdcall gos_ConvertTextureRect( DWORD Handle, DWORD DestLeft, DWORD DestTop, DWORD *Source, DWORD SourcePitch, DWORD Width, DWORD Height );

--- a/code/clean_mp4_player.cpp
+++ b/code/clean_mp4_player.cpp
@@ -1,0 +1,502 @@
+// clean_mp4_player.cpp — Standalone MP4 player
+// Zero game engine dependencies. FFmpeg + SDL2 + OpenGL only.
+//
+// Architecture (same as ffplay/VLC):
+//   Demuxer reads packets and routes to separate audio/video queues.
+//   Audio queue: decoded immediately, PCM fed to SDL callback.
+//   Video queue: decoded on demand, one frame at a time, PTS-gated.
+//   Audio callback is the master clock. Wall-clock fallback for no-audio.
+
+#include <SDL2/SDL.h>
+#include <GL/glew.h>
+#include <GL/gl.h>
+#include <atomic>
+#include <iostream>
+#include <mutex>
+#include <queue>
+#include <string>
+
+extern "C" {
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+#include <libavutil/imgutils.h>
+#include <libavutil/opt.h>
+#include <libswresample/swresample.h>
+#include <libswscale/swscale.h>
+}
+
+// ---------------------------------------------------------------------------
+// Audio PCM queue — fed by main thread, drained by SDL callback
+// ---------------------------------------------------------------------------
+struct AudioChunk {
+    uint8_t* data;
+    int size;
+    int offset;
+    double pts;
+};
+
+struct AudioState {
+    std::mutex mutex;
+    std::queue<AudioChunk> queue;
+    SDL_AudioDeviceID device = 0;
+    SDL_AudioSpec spec{};
+    std::atomic<double> clock{0.0};
+    int sampleRate = 0;
+    int channels = 0;
+};
+
+static void audioCallback(void* userdata, Uint8* stream, int len) {
+    auto* audio = static_cast<AudioState*>(userdata);
+    std::lock_guard<std::mutex> lock(audio->mutex);
+
+    int written = 0;
+    SDL_memset(stream, 0, len);
+
+    while (written < len && !audio->queue.empty()) {
+        AudioChunk& chunk = audio->queue.front();
+        int available = chunk.size - chunk.offset;
+        int toCopy = std::min(len - written, available);
+
+        SDL_memcpy(stream + written, chunk.data + chunk.offset, toCopy);
+        chunk.offset += toCopy;
+        written += toCopy;
+
+        if (chunk.pts >= 0 && audio->sampleRate > 0) {
+            double bytesPerSec = audio->sampleRate * audio->channels * 2.0;
+            audio->clock.store(chunk.pts + chunk.offset / bytesPerSec);
+        }
+
+        if (chunk.offset >= chunk.size) {
+            delete[] chunk.data;
+            audio->queue.pop();
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+int main(int argc, char* argv[]) {
+    if (argc < 2) {
+        std::cout << "Usage: clean_mp4_player <video.mp4> [widthxheight]\n";
+        return 1;
+    }
+
+    std::string videoPath = argv[1];
+    int winW = 1280, winH = 720;
+    if (argc >= 3) {
+        std::string dim = argv[2];
+        auto xpos = dim.find('x');
+        if (xpos != std::string::npos) {
+            winW = std::atoi(dim.substr(0, xpos).c_str());
+            winH = std::atoi(dim.substr(xpos + 1).c_str());
+        } else {
+            winW = std::atoi(argv[2]);
+            if (argc >= 4) winH = std::atoi(argv[3]);
+        }
+    }
+
+    // -- SDL init --
+    if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_TIMER) != 0) {
+        std::cerr << "SDL_Init: " << SDL_GetError() << "\n";
+        return 1;
+    }
+
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 1);
+    SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
+
+    SDL_Window* window = SDL_CreateWindow(
+        "Clean MP4 Player", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
+        winW, winH, SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE);
+    if (!window) { std::cerr << "Window: " << SDL_GetError() << "\n"; return 1; }
+
+    SDL_GLContext glCtx = SDL_GL_CreateContext(window);
+    if (!glCtx) { std::cerr << "GL ctx: " << SDL_GetError() << "\n"; return 1; }
+    SDL_GL_MakeCurrent(window, glCtx);
+    SDL_GL_SetSwapInterval(1);
+
+    if (glewInit() != GLEW_OK) { std::cerr << "GLEW init failed\n"; return 1; }
+
+    // -- FFmpeg: open file, find streams --
+    AVFormatContext* fmtCtx = nullptr;
+    if (avformat_open_input(&fmtCtx, videoPath.c_str(), nullptr, nullptr) < 0) {
+        std::cerr << "Cannot open: " << videoPath << "\n";
+        return 1;
+    }
+    avformat_find_stream_info(fmtCtx, nullptr);
+
+    // Video stream
+    int vidIdx = -1;
+    AVCodecContext* vidCtx = nullptr;
+    for (unsigned i = 0; i < fmtCtx->nb_streams; i++) {
+        if (fmtCtx->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_VIDEO) {
+            vidIdx = (int)i;
+            break;
+        }
+    }
+    if (vidIdx < 0) { std::cerr << "No video stream\n"; return 1; }
+    {
+        const AVCodec* codec = avcodec_find_decoder(fmtCtx->streams[vidIdx]->codecpar->codec_id);
+        vidCtx = avcodec_alloc_context3(codec);
+        avcodec_parameters_to_context(vidCtx, fmtCtx->streams[vidIdx]->codecpar);
+        avcodec_open2(vidCtx, codec, nullptr);
+    }
+    double vidTimeBase = av_q2d(fmtCtx->streams[vidIdx]->time_base);
+    double fps = av_q2d(fmtCtx->streams[vidIdx]->r_frame_rate);
+    double frameDur = fps > 0 ? 1.0 / fps : 1.0 / 24.0;
+    int vidW = vidCtx->width, vidH = vidCtx->height;
+    std::cout << "Video: " << vidW << "x" << vidH << " @ " << fps << " FPS\n";
+
+    SwsContext* swsCtx = sws_getContext(
+        vidW, vidH, vidCtx->pix_fmt,
+        vidW, vidH, AV_PIX_FMT_RGBA,
+        SWS_BILINEAR, nullptr, nullptr, nullptr);
+
+    AVFrame* decFrame = av_frame_alloc();
+    AVFrame* rgbFrame = av_frame_alloc();
+
+    // IMPORTANT: sws_scale with SWS_BILINEAR uses SIMD that can overrun the
+    // last row's tail by up to ~32 bytes on widths that aren't SIMD-friendly
+    // (e.g. 76-pixel pilot-portrait clips). We keep align=1 so FFmpeg uses
+    // packed row strides (downstream memcpy/GL assume that), but allocate with
+    // a tail guard so the overrun lands in harmless memory instead of
+    // corrupting the heap.
+    const int SWS_TAIL_GUARD = 64;
+    int rgbBufSize = av_image_get_buffer_size(AV_PIX_FMT_RGBA, vidW, vidH, 1);
+    uint8_t* rgbBuf = new uint8_t[rgbBufSize + SWS_TAIL_GUARD];
+    av_image_fill_arrays(rgbFrame->data, rgbFrame->linesize, rgbBuf, AV_PIX_FMT_RGBA, vidW, vidH, 1);
+
+    // Audio stream
+    int audIdx = -1;
+    AVCodecContext* audCtx = nullptr;
+    SwrContext* swrCtx = nullptr;
+    AudioState audio;
+    bool hasAudio = false;
+    for (unsigned i = 0; i < fmtCtx->nb_streams; i++) {
+        if (fmtCtx->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_AUDIO) {
+            audIdx = (int)i;
+            break;
+        }
+    }
+    if (audIdx >= 0) {
+        const AVCodec* codec = avcodec_find_decoder(fmtCtx->streams[audIdx]->codecpar->codec_id);
+        audCtx = avcodec_alloc_context3(codec);
+        avcodec_parameters_to_context(audCtx, fmtCtx->streams[audIdx]->codecpar);
+        avcodec_open2(audCtx, codec, nullptr);
+
+        audio.sampleRate = audCtx->sample_rate;
+        audio.channels = audCtx->ch_layout.nb_channels;
+
+        swrCtx = swr_alloc();
+        av_opt_set_chlayout(swrCtx, "in_chlayout", &audCtx->ch_layout, 0);
+        av_opt_set_chlayout(swrCtx, "out_chlayout", &audCtx->ch_layout, 0);
+        av_opt_set_int(swrCtx, "in_sample_rate", audCtx->sample_rate, 0);
+        av_opt_set_int(swrCtx, "out_sample_rate", audCtx->sample_rate, 0);
+        av_opt_set_sample_fmt(swrCtx, "in_sample_fmt", audCtx->sample_fmt, 0);
+        av_opt_set_sample_fmt(swrCtx, "out_sample_fmt", AV_SAMPLE_FMT_S16, 0);
+        swr_init(swrCtx);
+
+        SDL_AudioSpec want{};
+        want.freq = audCtx->sample_rate;
+        want.format = AUDIO_S16SYS;
+        want.channels = (Uint8)audio.channels;
+        want.samples = 2048;
+        want.callback = audioCallback;
+        want.userdata = &audio;
+
+        audio.device = SDL_OpenAudioDevice(nullptr, 0, &want, &audio.spec, 0);
+        if (audio.device > 0) {
+            hasAudio = true;
+            std::cout << "Audio: " << audCtx->sample_rate << " Hz, "
+                      << audio.channels << " ch\n";
+        } else {
+            std::cerr << "Audio device failed: " << SDL_GetError() << "\n";
+        }
+    }
+    double audTimeBase = (audIdx >= 0) ? av_q2d(fmtCtx->streams[audIdx]->time_base) : 0;
+    AVFrame* audFrame = av_frame_alloc();
+
+    // -- GL texture --
+    GLuint tex = 0;
+    glGenTextures(1, &tex);
+    glBindTexture(GL_TEXTURE_2D, tex);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, vidW, vidH, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glBindTexture(GL_TEXTURE_2D, 0);
+
+    // =====================================================================
+    // PACKET QUEUES — the key architectural difference from before.
+    // Demuxer feeds both queues. Audio and video consume independently.
+    // =====================================================================
+    std::queue<AVPacket*> videoPacketQueue;
+    // (Audio PCM queue is inside AudioState)
+
+    // -- Playback state --
+    Uint64 perfFreq = SDL_GetPerformanceFrequency();
+    Uint64 startCounter = 0;
+    bool audioStarted = false;
+    bool clockRunning = false;
+
+    uint8_t* pendingData = new uint8_t[rgbBufSize + SWS_TAIL_GUARD];
+    double pendingPts = -1.0;
+    bool hasPending = false;
+
+    auto getClock = [&]() -> double {
+        if (hasAudio && audioStarted) return audio.clock.load();
+        if (clockRunning) return (double)(SDL_GetPerformanceCounter() - startCounter) / (double)perfFreq;
+        return 0.0;
+    };
+
+    bool running = true;
+    bool demuxEof = false;
+    int frameCount = 0;
+    int lastLoggedFrame = -1;
+    const int AUDIO_PRIME_CHUNKS = 8;
+
+    while (running) {
+        // -- Events --
+        SDL_Event ev;
+        while (SDL_PollEvent(&ev)) {
+            if (ev.type == SDL_QUIT) running = false;
+            if (ev.type == SDL_KEYDOWN) {
+                if (ev.key.keysym.sym == SDLK_ESCAPE || ev.key.keysym.sym == SDLK_q)
+                    running = false;
+            }
+        }
+        if (!running) break;
+
+        double clock = getClock();
+
+        // =================================================================
+        // STEP 1: Demux — read packets and route to queues
+        // =================================================================
+        if (!demuxEof) {
+            int audioPcmSize;
+            { std::lock_guard<std::mutex> lock(audio.mutex); audioPcmSize = (int)audio.queue.size(); }
+
+            // Keep reading until both queues have enough, or we've read enough packets
+            bool audioHungry = audioPcmSize < 15;
+            bool videoHungry = (int)videoPacketQueue.size() < 30;
+
+            int packetsRead = 0;
+            while (packetsRead < 80 && (audioHungry || videoHungry)) {
+                AVPacket* pkt = av_packet_alloc();
+                if (av_read_frame(fmtCtx, pkt) < 0) {
+                    demuxEof = true;
+                    av_packet_free(&pkt);
+                    break;
+                }
+                packetsRead++;
+
+                if (pkt->stream_index == vidIdx) {
+                    videoPacketQueue.push(pkt); // ownership transferred to queue
+                } else if (pkt->stream_index == audIdx && audCtx) {
+                    // Decode audio immediately and queue PCM
+                    if (avcodec_send_packet(audCtx, pkt) == 0) {
+                        while (avcodec_receive_frame(audCtx, audFrame) == 0) {
+                            int outSamples = swr_get_out_samples(swrCtx, audFrame->nb_samples);
+                            if (outSamples <= 0) continue;
+                            int bufSize = outSamples * audio.channels * 2;
+                            uint8_t* buf = new uint8_t[bufSize];
+                            int converted = swr_convert(swrCtx, &buf, outSamples,
+                                (const uint8_t**)audFrame->data, audFrame->nb_samples);
+                            if (converted > 0) {
+                                double aPts = pkt->pts * audTimeBase;
+                                std::lock_guard<std::mutex> lock(audio.mutex);
+                                audio.queue.push({buf, converted * audio.channels * 2, 0, aPts});
+                            } else {
+                                delete[] buf;
+                            }
+                        }
+                    }
+                    av_packet_unref(pkt);
+                    av_packet_free(&pkt);
+                } else {
+                    // Other streams — discard
+                    av_packet_unref(pkt);
+                    av_packet_free(&pkt);
+                }
+
+                // Re-check hunger
+                { std::lock_guard<std::mutex> lock(audio.mutex); audioHungry = (int)audio.queue.size() < 15; }
+                videoHungry = (int)videoPacketQueue.size() < 30;
+            }
+        }
+
+        // =================================================================
+        // STEP 2: Start audio once primed
+        // =================================================================
+        if (hasAudio && !audioStarted) {
+            int qsz;
+            { std::lock_guard<std::mutex> lock(audio.mutex); qsz = (int)audio.queue.size(); }
+            if (qsz >= AUDIO_PRIME_CHUNKS || demuxEof) {
+                audio.clock.store(0.0);
+                SDL_PauseAudioDevice(audio.device, 0);
+                audioStarted = true;
+                clockRunning = true;
+                std::cout << "Audio started (queue: " << qsz << ")\n";
+            }
+        }
+        if (!hasAudio && !clockRunning && !videoPacketQueue.empty()) {
+            startCounter = SDL_GetPerformanceCounter();
+            clockRunning = true;
+        }
+
+        // =================================================================
+        // STEP 3: Check pending video frame
+        // =================================================================
+        clock = getClock();
+        if (hasPending && pendingPts <= clock + 0.005) {
+            glBindTexture(GL_TEXTURE_2D, tex);
+            glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, vidW, vidH, GL_RGBA, GL_UNSIGNED_BYTE, pendingData);
+            glBindTexture(GL_TEXTURE_2D, 0);
+            frameCount++;
+            hasPending = false;
+        }
+
+        // =================================================================
+        // STEP 4: Decode video from packet queue (one frame at a time)
+        // =================================================================
+        while (!hasPending && !videoPacketQueue.empty()) {
+            AVPacket* pkt = videoPacketQueue.front();
+            videoPacketQueue.pop();
+
+            if (avcodec_send_packet(vidCtx, pkt) == 0) {
+                while (avcodec_receive_frame(vidCtx, decFrame) == 0) {
+                    sws_scale(swsCtx, decFrame->data, decFrame->linesize, 0, vidH,
+                              rgbFrame->data, rgbFrame->linesize);
+                    int64_t pts = decFrame->best_effort_timestamp;
+                    if (pts == AV_NOPTS_VALUE) pts = 0;
+                    double framePts = pts * vidTimeBase;
+
+                    clock = getClock();
+
+                    if (!clockRunning || framePts <= clock + 0.005) {
+                        // Due now — display
+                        glBindTexture(GL_TEXTURE_2D, tex);
+                        glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, vidW, vidH,
+                            GL_RGBA, GL_UNSIGNED_BYTE, rgbFrame->data[0]);
+                        glBindTexture(GL_TEXTURE_2D, 0);
+                        frameCount++;
+
+                        // Frame drop if behind
+                        if (clockRunning && framePts < clock - frameDur) continue;
+                    } else {
+                        // Future frame — buffer as pending
+                        memcpy(pendingData, rgbFrame->data[0], rgbBufSize);
+                        pendingPts = framePts;
+                        hasPending = true;
+                    }
+                    break; // one frame per packet typically
+                }
+            }
+
+            av_packet_unref(pkt);
+            av_packet_free(&pkt);
+
+            if (hasPending) break; // got our next frame, stop decoding
+        }
+
+        // =================================================================
+        // STEP 5: EOF — done when both queues empty
+        // =================================================================
+        if (demuxEof && videoPacketQueue.empty() && !hasPending) {
+            int qsz;
+            { std::lock_guard<std::mutex> lock(audio.mutex); qsz = (int)audio.queue.size(); }
+            if (qsz == 0) {
+                SDL_Delay(200);
+                running = false;
+                continue;
+            }
+        }
+
+        // =================================================================
+        // STEP 6: Render
+        // =================================================================
+        int drawW, drawH;
+        SDL_GL_GetDrawableSize(window, &drawW, &drawH);
+        glViewport(0, 0, drawW, drawH);
+        glClearColor(0, 0, 0, 1);
+        glClear(GL_COLOR_BUFFER_BIT);
+
+        float vidAspect = (float)vidW / vidH;
+        float winAspect = (float)drawW / drawH;
+        float qw, qh;
+        if (vidAspect > winAspect) {
+            qw = 1.0f;
+            qh = winAspect / vidAspect;
+        } else {
+            qh = 1.0f;
+            qw = vidAspect / winAspect;
+        }
+
+        glMatrixMode(GL_PROJECTION);
+        glLoadIdentity();
+        glOrtho(-1, 1, -1, 1, -1, 1);
+        glMatrixMode(GL_MODELVIEW);
+        glLoadIdentity();
+
+        glEnable(GL_TEXTURE_2D);
+        glBindTexture(GL_TEXTURE_2D, tex);
+        glColor4f(1, 1, 1, 1);
+        glBegin(GL_QUADS);
+        glTexCoord2f(0, 0); glVertex2f(-qw,  qh);
+        glTexCoord2f(1, 0); glVertex2f( qw,  qh);
+        glTexCoord2f(1, 1); glVertex2f( qw, -qh);
+        glTexCoord2f(0, 1); glVertex2f(-qw, -qh);
+        glEnd();
+        glDisable(GL_TEXTURE_2D);
+        glBindTexture(GL_TEXTURE_2D, 0);
+
+        SDL_GL_SwapWindow(window);
+
+        // Log every 60 frames
+        if (frameCount > 0 && frameCount % 60 == 0 && frameCount != lastLoggedFrame) {
+            lastLoggedFrame = frameCount;
+            int aq, vq;
+            { std::lock_guard<std::mutex> lock(audio.mutex); aq = (int)audio.queue.size(); }
+            vq = (int)videoPacketQueue.size();
+            std::cout << "Frame " << frameCount << " | clock: " << clock
+                      << "s | audio_q: " << aq << " | video_q: " << vq << "\n";
+        }
+    }
+
+    // -- Stats --
+    double finalClock = getClock();
+    double expectedFrames = finalClock * fps;
+    std::cout << "\nDone. " << frameCount << " frames displayed in "
+              << finalClock << "s (expected ~" << (int)expectedFrames
+              << " at " << fps << " FPS)\n";
+
+    // -- Cleanup --
+    if (audio.device) {
+        SDL_PauseAudioDevice(audio.device, 1);
+        SDL_CloseAudioDevice(audio.device);
+    }
+    { std::lock_guard<std::mutex> lock(audio.mutex);
+      while (!audio.queue.empty()) { delete[] audio.queue.front().data; audio.queue.pop(); } }
+    while (!videoPacketQueue.empty()) {
+        av_packet_unref(videoPacketQueue.front());
+        av_packet_free(&videoPacketQueue.front());
+        videoPacketQueue.pop();
+    }
+
+    delete[] pendingData;
+    glDeleteTextures(1, &tex);
+    delete[] rgbBuf;
+    av_frame_free(&decFrame);
+    av_frame_free(&rgbFrame);
+    av_frame_free(&audFrame);
+    sws_freeContext(swsCtx);
+    if (swrCtx) swr_free(&swrCtx);
+    if (audCtx) avcodec_free_context(&audCtx);
+    avcodec_free_context(&vidCtx);
+    avformat_close_input(&fmtCtx);
+
+    SDL_GL_DeleteContext(glCtx);
+    SDL_DestroyWindow(window);
+    SDL_Quit();
+    return 0;
+}

--- a/code/controlgui.cpp
+++ b/code/controlgui.cpp
@@ -9,11 +9,14 @@ controlGui.cpp			: Implementation of the controlGui component.
 #include"team.h"
 #include"gamesound.h"
 #include"comndr.h"
+#include"mc2movie.h"
+#include <iostream>
 
 #ifndef MULTPLYR_H
 #include"multplyr.h"
 #endif
 
+#include <SDL2/SDL.h>
 
 #ifndef GAMETACMAP_H
 #include"gametacmap.h"
@@ -22,6 +25,8 @@ controlGui.cpp			: Implementation of the controlGui component.
 #ifndef LOGISTICSDATA_H
 #include"logisticsdata.h"
 #endif
+
+#include"windows.h"
 
 #ifndef PAUSEWINDOW_H
 #include"pausewindow.h"
@@ -52,6 +57,8 @@ ButtonData* ControlGui::vehicleData = NULL;
 
 long ControlGui::hiResOffsetX = 0;
 long ControlGui::hiResOffsetY = 0;
+long ControlGui::fitBakedHiResOffsetX = 0;
+long ControlGui::fitBakedHiResOffsetY = 0;
 
 long ControlGui::OBJECTIVESTOP= 0;
 long ControlGui::OBJECTIVESLEFT= 0;
@@ -359,11 +366,59 @@ void ControlGui::render( bool bPaused )
 		RenderObjectives();
 	}
 
-	if ( moviePlaying && bMovie)
+	if ( moviePlaying && bMovie && bMovie->getTextureHandle() )
 	{
+		// [FMV_DIAG] TEMPORARY — log first-frame draw coords.
+		static bool fmvDiagLogged = false;
+		if ( !fmvDiagLogged )
+		{
+			fmvDiagLogged = true;
+			std::cout << "[FMV_DIAG] render: videoRect = ("
+			          << videoRect.left << ", " << videoRect.top << ", "
+			          << videoRect.right << ", " << videoRect.bottom << ")\n";
+			for ( int i = 0; i < videoInfoCount; i++ )
+			{
+				std::cout << "[FMV_DIAG] render: VideoStatic" << i
+				          << " quad = (" << videoInfos[i].location[0].x
+				          << ", " << videoInfos[i].location[0].y
+				          << ") to (" << videoInfos[i].location[2].x
+				          << ", " << videoInfos[i].location[2].y << ")\n";
+			}
+		}
+
+		// Draw order per FMV_DESIGN.md §7.2:
+		//   panel backdrop (already drawn above) → videoInfos border → video quad
 		for ( int i = 0; i < videoInfoCount; i++ )
 			videoInfos[i].render();
-		bMovie->render();
+
+		// videoRect is loaded from buttonlayout{res}.fit and already has
+		// hiResOffsetX/Y baked in (see :2491-2496) — no further offset needed.
+		gos_VERTEX v[4];
+		for ( int i = 0; i < 4; i++ )
+		{
+			v[i].argb = 0xffffffff;   // shader multiplies vertex color into texel
+			v[i].frgb = 0;
+			v[i].rhw = .5;
+			v[i].u = 0.f;
+			v[i].v = 0.f;
+			v[i].x = videoRect.left;
+			v[i].y = videoRect.top;
+			v[i].z = 0.f;
+		}
+		v[2].x = v[3].x = videoRect.right;
+		v[2].y = v[1].y = videoRect.bottom;
+		v[2].u = v[3].u = 1.0f;
+		v[2].v = v[1].v = 1.0f;
+
+		gos_SetRenderState( gos_State_Texture,   bMovie->getTextureHandle() );
+		// Bilinear on the video quad — we upscale the 128x72 source by 1.5x
+		// (and more at higher resolutions), so point filtering looks chunky.
+		// Borders use StaticInfo::render which sets gos_FilterNone itself, so
+		// their crispness is not affected by this.
+		gos_SetRenderState( gos_State_Filter,    gos_FilterBiLinear );
+		gos_SetRenderState( gos_State_AlphaMode, gos_Alpha_OneZero );
+		gos_DrawQuads( v, 4 );
+		gos_SetRenderState( gos_State_Texture,   0 );
 	}
 
 	if (drawGUIOn)
@@ -938,8 +993,8 @@ void ControlGui::update( bool bPaused, bool bLOS )
 
 	if (moviePlaying && bMovie)
 	{
-		bool result = bMovie->update();
-		if (result)
+		bMovie->update();
+		if (!bMovie->isPlaying())
 		{
 			moviePlaying = false;
 			delete bMovie;
@@ -2487,8 +2542,22 @@ void ControlGui::initStatics( FitIniFile& file )
 	file.readIdLong( "right", 	videoRect.right );
 	file.readIdLong( "top", 	videoRect.top );
 	file.readIdLong( "bottom", 	videoRect.bottom );
-	videoRect.left += hiResOffsetX;
-	videoRect.right += hiResOffsetX;
+
+	// [FMV_DIAG] TEMPORARY — remove after diagnosing frame/video misalignment.
+	std::cout << "[FMV_DIAG] hiResOffset = (" << hiResOffsetX << ", " << hiResOffsetY << ")\n";
+	std::cout << "[FMV_DIAG] videoRect raw   = ("
+	          << videoRect.left << ", " << videoRect.top << ", "
+	          << videoRect.right << ", " << videoRect.bottom << ")\n";
+
+	videoRect.left   += hiResOffsetX;
+	videoRect.right  += hiResOffsetX;
+	videoRect.top    += hiResOffsetY;
+	videoRect.bottom += hiResOffsetY;
+
+	// [FMV_DIAG] TEMPORARY
+	std::cout << "[FMV_DIAG] videoRect final = ("
+	          << videoRect.left << ", " << videoRect.top << ", "
+	          << videoRect.right << ", " << videoRect.bottom << ")\n";
 
 	file.seekBlock( "VideoTextBox" );
 	file.readIdLong( "left", 	videoTextRect.left );
@@ -2501,11 +2570,117 @@ void ControlGui::initStatics( FitIniFile& file )
 
 	if ( videoInfoCount )
 	{
+		// VideoStatic quads have hiResOffsetX pre-baked into their X coords in
+		// the 1280/1600/1920 .fit files (e.g. 1600.fit: VideoStatic0.XLocation
+		// = 1180 + 288 = 1468 ≈ 1467). Subtract the baked amount so the runtime
+		// X offset from init() lands them aligned with videoRect. Y was never
+		// baked — VideoStatic.YLocation is always 0/77 regardless of res — so
+		// we pass the full runtime Y through.
+		const long staticXOffset = hiResOffsetX - fitBakedHiResOffsetX;
+		const long staticYOffset = hiResOffsetY;
+
 		videoInfos = new StaticInfo[videoInfoCount];
 		for ( i = 0; i < videoInfoCount; i++ )
 		{
 			sprintf( blockName, "VideoStatic%ld", i );
-			videoInfos[i].init( file, blockName );
+			videoInfos[i].init( file, blockName, staticXOffset, staticYOffset );
+
+			// [FMV_DIAG] TEMPORARY — log post-init quad bounds for each VideoStatic.
+			std::cout << "[FMV_DIAG] " << blockName
+			          << " location = (" << videoInfos[i].location[0].x
+			          << ", " << videoInfos[i].location[0].y
+			          << ") to (" << videoInfos[i].location[2].x
+			          << ", " << videoInfos[i].location[2].y << ")\n";
+		}
+
+		// Dock the FMV panel (video + borders + text rect) to the top-right
+		// corner of the screen, and scale the whole group uniformly. Done as
+		// a single rigid-body transform so the frame art stays aligned with
+		// the video quad regardless of the source .fit resolution.
+		const float fmvScale = 1.5f;
+
+		// 1) Compute bounding box of the current group (post-offset coords).
+		float bbLeft   = (float)videoRect.left;
+		float bbTop    = (float)videoRect.top;
+		float bbRight  = (float)videoRect.right;
+		float bbBottom = (float)videoRect.bottom;
+		for ( i = 0; i < videoInfoCount; i++ )
+		{
+			for ( int k = 0; k < 4; k++ )
+			{
+				if ( videoInfos[i].location[k].x < bbLeft )   bbLeft   = videoInfos[i].location[k].x;
+				if ( videoInfos[i].location[k].y < bbTop )    bbTop    = videoInfos[i].location[k].y;
+				if ( videoInfos[i].location[k].x > bbRight )  bbRight  = videoInfos[i].location[k].x;
+				if ( videoInfos[i].location[k].y > bbBottom ) bbBottom = videoInfos[i].location[k].y;
+			}
+		}
+		const float groupW = bbRight - bbLeft;
+		const float groupH = bbBottom - bbTop;
+
+		// 2) Target: pin scaled group's right edge to screen right, top to y=0.
+		const float targetRight = (float)Environment.screenWidth;
+		const float targetTop   = 0.0f;
+		const float scaledW     = groupW * fmvScale;
+		const float scaledH     = groupH * fmvScale;
+		const float targetLeft  = targetRight - scaledW;
+		const float targetBottom = targetTop + scaledH;
+
+		// 3) Transform a point from old-group space to new-group space.
+		auto xform = [&](float oldX, float oldY, float& outX, float& outY)
+		{
+			outX = targetLeft + (oldX - bbLeft) * fmvScale;
+			outY = targetTop  + (oldY - bbTop)  * fmvScale;
+		};
+
+		// 4) Apply to videoRect. GUI_RECT is long, so round.
+		float nxL, nyT, nxR, nyB;
+		xform((float)videoRect.left,  (float)videoRect.top,    nxL, nyT);
+		xform((float)videoRect.right, (float)videoRect.bottom, nxR, nyB);
+		videoRect.left   = (long)(nxL + 0.5f);
+		videoRect.top    = (long)(nyT + 0.5f);
+		videoRect.right  = (long)(nxR + 0.5f);
+		videoRect.bottom = (long)(nyB + 0.5f);
+
+		// 5) Apply to each border quad vertex.
+		for ( i = 0; i < videoInfoCount; i++ )
+		{
+			for ( int k = 0; k < 4; k++ )
+			{
+				float nx, ny;
+				xform(videoInfos[i].location[k].x, videoInfos[i].location[k].y, nx, ny);
+				videoInfos[i].location[k].x = nx;
+				videoInfos[i].location[k].y = ny;
+			}
+		}
+
+		// 6) videoTextRect (briefing captions inside the video panel). Its Y
+		// was never offset at load time, so we synthesize a top/bottom relative
+		// to the pre-transform videoRect, then map through xform.
+		{
+			float ntxL, ntyT, ntxR, ntyB;
+			xform((float)videoTextRect.left,  (float)videoTextRect.top,    ntxL, ntyT);
+			xform((float)videoTextRect.right, (float)videoTextRect.bottom, ntxR, ntyB);
+			videoTextRect.left   = (long)(ntxL + 0.5f);
+			videoTextRect.top    = (long)(ntyT + 0.5f);
+			videoTextRect.right  = (long)(ntxR + 0.5f);
+			videoTextRect.bottom = (long)(ntyB + 0.5f);
+		}
+
+		// [FMV_DIAG] Log the post-transform geometry so we can confirm.
+		std::cout << "[FMV_DIAG] post-xform videoRect = ("
+		          << videoRect.left << ", " << videoRect.top << ", "
+		          << videoRect.right << ", " << videoRect.bottom
+		          << ")  group bbox was (" << bbLeft << "," << bbTop
+		          << ")-(" << bbRight << "," << bbBottom
+		          << ")  scaled to (" << targetLeft << "," << targetTop
+		          << ")-(" << targetRight << "," << targetBottom << ")\n";
+		for ( i = 0; i < videoInfoCount; i++ )
+		{
+			std::cout << "[FMV_DIAG] post-xform VideoStatic" << i
+			          << " = (" << videoInfos[i].location[0].x
+			          << "," << videoInfos[i].location[0].y
+			          << ")-(" << videoInfos[i].location[2].x
+			          << "," << videoInfos[i].location[2].y << ")\n";
 		}
 	}
 
@@ -2673,7 +2848,7 @@ void ControlGui::swapResolutions( int resolutionX, int resolutionY )
 		result = buttonFile.readIdLong("xOffset",hiResOffsetX);
 		if (result != NO_ERR)
 			hiResOffsetX = 0;
-			
+
 		result = buttonFile.readIdLong("yOffset",hiResOffsetY);
 		if (result != NO_ERR)
 			hiResOffsetY = 0;
@@ -2682,6 +2857,12 @@ void ControlGui::swapResolutions( int resolutionX, int resolutionY )
 	{
 		hiResOffsetX = hiResOffsetY = 0;
 	}
+
+	// Snapshot the raw offsets before x_correction / y_correction below; we
+	// need them to un-bake coordinates that .fit authors hard-coded with the
+	// HiresOffsets values pre-applied (VideoStatic frame quads, specifically).
+	fitBakedHiResOffsetX = hiResOffsetX;
+	fitBakedHiResOffsetY = hiResOffsetY;
 
 	if ( resolutionX == 1920) {
         y_correction = resolutionY - (768 + hiResOffsetY);
@@ -2847,8 +3028,12 @@ void ControlGui::switchTabs(int direction)
 
 void ControlGui::playMovie( const char* fileName )
 {
+	std::cout << "[ControlGui] playMovie called with: " << (fileName ? fileName : "NULL") << "\n";
 	if (moviePlaying)
+	{
+		std::cout << "[ControlGui] Movie already playing, returning\n";
 		return;
+	}
 
 	RECT vRect;
 	vRect.left = videoRect.left;
@@ -2863,9 +3048,26 @@ void ControlGui::playMovie( const char* fileName )
 	_splitpath(fileName,NULL,NULL,realName,NULL);
 
 	FullPathFileName movieName;
-	movieName.init(moviePath,realName,".bik");
-	bMovie = new MC2Movie;
-	bMovie->init(movieName,vRect,true);
+	//movieName.init(moviePath,realName,".mp4");F
+	movieName.init(moviePath,realName,".mp4");
+	std::cout << "[ControlGui] Full movie path: " << (const char*)movieName << "\n";
+	
+	std::cout << "[ControlGui] Creating MC2Movie\n";
+
+	bMovie = new MC2Movie();
+
+	RECT convertedRect = { vRect.left, vRect.top, vRect.right, vRect.bottom };
+
+	std::cout << "[ControlGui] Movie rect: " << convertedRect.left << "," << convertedRect.top
+	          << " " << (convertedRect.right - convertedRect.left) << "x" << (convertedRect.bottom - convertedRect.top) << "\n";
+
+	if ( !bMovie->init( (const char*)movieName, convertedRect, false ) ) // don't loop cutscenes
+	{
+		std::cout << "[ControlGui] ERROR: init failed for " << (const char*)movieName << "\n";
+		delete bMovie;
+		bMovie = nullptr;
+		return;
+	}
 
 	//Maybe not enough frames to run.  Do not flash the border!
 	// Do ONE update to make sure the damned sound starts at least!!
@@ -2873,6 +3075,7 @@ void ControlGui::playMovie( const char* fileName )
 	if (bMovie->isPlaying())
 	{
 		moviePlaying = true;
+		std::cout << "[ControlGui] Movie started playing successfully\n";
 	}
 	else
 	{
@@ -2880,6 +3083,7 @@ void ControlGui::playMovie( const char* fileName )
 		moviePlaying = false;
 		delete bMovie;
 		bMovie = NULL;
+		std::cout << "[ControlGui] Movie failed to start playing\n";
 	}
 }
 

--- a/code/controlgui.h
+++ b/code/controlgui.h
@@ -36,7 +36,7 @@ ControlGui.h			: Interface for the ControlGui component.  This thing holds the t
 #include"aedit.h"
 #endif
 
-#ifndef MC2movie_H
+#ifndef MC2MOVIE_H
 #include"mc2movie.h"
 #endif
 
@@ -124,6 +124,12 @@ class ControlGui
 
 		static long			hiResOffsetX;
 		static long			hiResOffsetY;
+		// Raw HiresOffsets values as read from the .fit file (before
+		// x_correction / y_correction). .fit authors pre-baked these into
+		// certain static quad coordinates (notably VideoStatic), so we need
+		// the raw values to unbake them before applying the runtime offsets.
+		static long			fitBakedHiResOffsetX;
+		static long			fitBakedHiResOffsetY;
 
 		ControlGui();
 		~ControlGui();
@@ -365,7 +371,7 @@ class ControlGui
 		long				videoInfoCount;
 		GUI_RECT			videoRect;
 		GUI_RECT			videoTextRect;
-		MC2MoviePtr			bMovie;
+		MC2Movie*			bMovie;
 
 		StaticInfo*			timerInfos;
 		long				timerInfoCount;

--- a/code/forcegroupbar.cpp
+++ b/code/forcegroupbar.cpp
@@ -6,6 +6,8 @@ ForceGroupBar.cpp			: Implementation of the ForceGroupBar component.
 //===========================================================================//
 \*************************************************************************************************/
 
+#include <SDL2/SDL.h>
+#include <windows.h>
 #include"forcegroupbar.h"
 #include"mechicon.h"
 #include"objmgr.h"
@@ -14,10 +16,11 @@ ForceGroupBar.cpp			: Implementation of the ForceGroupBar component.
 #include"controlgui.h"
 #include "../resource.h"
 #include"multplyr.h"
-#include"mc2movie.h"
+#include"mp4player.h"
 #include"comndr.h"
 #include"prefs.h"
 #include"gamesound.h"
+#include <iostream>
 
 float ForceGroupBar::iconWidth = 48;
 float ForceGroupBar::iconHeight = 42;
@@ -412,24 +415,31 @@ bool ForceGroupBar::setPilotVideo( const char* pVideo, MechWarrior* pPilot )
 {
 	if ( !pVideo  )
 	{
-		if ( ForceGroupIcon::bMovie )
+		// Walk icons to find the current owner (at most one, per invariant) and
+		// free its player. Per-instance ownership means no static to poke.
+		for (int i = 0; i < iconCount; i++)
 		{
-			delete ForceGroupIcon::bMovie;
-			ForceGroupIcon::bMovie = NULL;
-			
+			if (icons[i] && icons[i]->bMovie)
+			{
+				delete icons[i]->bMovie;
+				icons[i]->bMovie = NULL;
+				break;
+			}
 		}
-		else if ( ForceGroupIcon::pilotVideoTexture )
+
+		// Unconditional fallback-texture destruction — cheap guard against a
+		// stale handle if the slot ever gets into mixed state.
+		if ( ForceGroupIcon::pilotVideoTexture )
 			gos_DestroyTexture( ForceGroupIcon::pilotVideoTexture );
-		
+
 		ForceGroupIcon::pilotVideoTexture = 0;
 		ForceGroupIcon::pilotVideoPilot = 0;
 	}
 
-	else if  (ForceGroupIcon::bMovie || ControlGui::instance->isMoviePlaying()
+	else if  (isPlayingVideo() || ControlGui::instance->isMoviePlaying()
 		|| ForceGroupIcon::pilotVideoTexture || !prefs.pilotVideos)
 	{
-		// one already playing...
-		// OR we don't want them playing.
+		// one already playing, or we don't want them playing.
 		return 0;
 	}
 
@@ -441,9 +451,17 @@ bool ForceGroupBar::setPilotVideo( const char* pVideo, MechWarrior* pPilot )
 			{
 				ForceGroupIcon::pilotVideoPilot = pPilot;
 				FullPathFileName aviPath;
-				aviPath.init( moviePath, pVideo, ".bik" );
+				aviPath.init( moviePath, pVideo, ".mp4" );
 
-				if ( (frameRate > 15.0) && fileExists(aviPath) && prefs.pilotVideos) // This is about correct.  Slower then this and movie has hard time keeping up!
+				const bool exists = fileExists(aviPath);
+
+				// Original gate was 15.0 FPS (a 2001-era "don't show video if CPU
+				// can't keep up" safeguard). On modern hardware the actual frame
+				// rate occasionally dips below 15 during load hitches, which flips
+				// the pilot portrait to a static .tga for that specific acknowledge-
+				// ment. Original game never did that -- it always played video when
+				// one existed. Lower the floor so transient hitches don't degrade.
+				if ( (frameRate > 5.0) && exists && prefs.pilotVideos)
 				{
 					//Update the RECT every frame.  What if we shift Icons around cause someone died!!
 					RECT vRect;
@@ -452,8 +470,22 @@ bool ForceGroupBar::setPilotVideo( const char* pVideo, MechWarrior* pPilot )
 					vRect.top 		= icons[i]->bmpLocation[icons[i]->locationIndex][3].y;
 					vRect.bottom 	= icons[i]->bmpLocation[icons[i]->locationIndex][1].y;
 
-					ForceGroupIcon::bMovie = new MC2Movie;
-					ForceGroupIcon::bMovie->init(aviPath,vRect,true);
+				SDL_Window* gameWindow = SDL_GL_GetCurrentWindow();
+				SDL_GLContext gameContext = SDL_GL_GetCurrentContext();
+
+				// Defensive: invariant is "at most one icon has bMovie non-null at
+				// a time." If a prior cleanup failed, leaking on this assignment
+				// would be silent. Walk other icons and free any stray owner.
+				for (int j = 0; j < iconCount; j++)
+				{
+					if (j != i && icons[j] && icons[j]->bMovie)
+					{
+						delete icons[j]->bMovie;
+						icons[j]->bMovie = NULL;
+					}
+				}
+				icons[i]->bMovie = new MP4Player(std::string(aviPath), gameWindow, gameContext);
+				icons[i]->bMovie->init(aviPath, RECT{vRect.left, vRect.top, vRect.right, vRect.bottom}, true, gameWindow, gameContext);
 				}
 				else // make a still texture
 				{
@@ -499,7 +531,7 @@ bool ForceGroupBar::setPilotVideo( const char* pVideo, MechWarrior* pPilot )
 							cLoadString(IDS_MC2_CDMISSING,msg,1023);
 							cLoadString(IDS_MC2_MISSING_TITLE,title,255);
 							sprintf(data,msg1,(const char*)path,msg);
-							DWORD result = MessageBox(NULL,data,title,MB_OKCANCEL | MB_ICONWARNING);
+							DWORD result = MessageBox((HWND)NULL, data, title, MB_OKCANCEL | MB_ICONWARNING);
 							if (result == IDCANCEL)
 							{
 								ExitGameOS();
@@ -526,9 +558,11 @@ bool ForceGroupBar::setPilotVideo( const char* pVideo, MechWarrior* pPilot )
 
 bool ForceGroupBar::isPlayingVideo()
 {
-	if ( ForceGroupIcon::bMovie )
-		return true;
-
+	for (int i = 0; i < iconCount; i++)
+	{
+		if (icons[i] && icons[i]->bMovie)
+			return true;
+	}
 	return false;
 }
 

--- a/code/logistics.cpp
+++ b/code/logistics.cpp
@@ -272,7 +272,13 @@ long Logistics::update(void)
         }
 
         bMovie->update();
-        if (bMovie)
+        // Wait for the movie to actually finish before tearing it down.
+        // Previously this was `if (bMovie)`, which is always true right
+        // after a `new`, so the full-screen video got deleted on frame 1
+        // before render() could ever draw it. controlgui.cpp:996-997
+        // (in-mission cinematics) already uses the correct !isPlaying()
+        // gate; this brings full-screen video in line with it.
+        if (!bMovie->isPlaying())
         {
             if (LogisticsData::instance->campaignOver() && (S_strnicmp(bMovie->getMovieName().c_str(), "credits", 7) == 0))
             {
@@ -296,7 +302,7 @@ long Logistics::update(void)
                 movieRect.top = 0;
                 movieRect.left = 0;
                 movieRect.right = Environment.screenWidth;
-                movieRect.bottom = 600;
+                movieRect.bottom = Environment.screenHeight;
 
                 SDL_Window* gameWindow = SDL_GL_GetCurrentWindow();
                 SDL_GLContext gameContext = SDL_GL_GetCurrentContext();
@@ -856,15 +862,33 @@ void Logistics::playFullScreenVideo(const char* fileName)
     if (!fileName || !fileName[0])
         return;
 
-    FullPathFileName movieName;
-    //movieName.init(moviePath, fileName, ".bik");
-    movieName.init(moviePath, fileName, ".mp4");
+    // Retail campaign.fit stores big-video names with a ".bik" extension
+    // (e.g. "cinema1.bik"). init() below appends ".mp4", which would
+    // otherwise produce the bogus path "cinema1.bik.mp4". Strip the
+    // extension only if it's terminal — don't maul a name that happens
+    // to contain ".bik" somewhere in the middle. Other video call sites
+    // either split via _splitpath (controlgui.cpp) or pass bare names
+    // (forcegroupbar.cpp), so the fix only needs to live here.
+    char basename[256];
+    strncpy(basename, fileName, sizeof(basename) - 1);
+    basename[sizeof(basename) - 1] = '\0';
+    size_t len = strlen(basename);
+    if (len >= 4 && S_stricmp(basename + len - 4, ".bik") == 0)
+        basename[len - 4] = '\0';
 
+    FullPathFileName movieName;
+    movieName.init(moviePath, basename, ".mp4");
+
+    // Full logical screen — MP4Player::render() aspect-preserves within the
+    // rect so widescreen source letterboxes cleanly on 16:9 displays and
+    // 4:3 source pillarboxes. Previously the rect was hardcoded to a
+    // 100-500 horizontal band, which squeezed the video into a ~400px-
+    // tall strip with black above and below.
     RECT movieRect;
-    movieRect.top = 100;
+    movieRect.top = 0;
     movieRect.left = 0;
     movieRect.right = Environment.screenWidth;
-    movieRect.bottom = 500;
+    movieRect.bottom = Environment.screenHeight;
 
     SDL_Window* gameWindow = SDL_GL_GetCurrentWindow();
     SDL_GLContext gameContext = SDL_GL_GetCurrentContext();

--- a/code/logistics.cpp
+++ b/code/logistics.cpp
@@ -10,67 +10,72 @@
 //----------------------------------------------------------------------------------
 // Include Files
 #ifndef LOGISTICS_H
-#include"logistics.h"
+#include "logistics.h"
 #endif
+
+#include <SDL2/SDL.h>
+#include <iostream>  // Add this for std::cerr
 
 #ifndef TEST_SHELL
 #ifndef MISSION_H
-#include"mission.h"
+#include "mission.h"
 #endif
 
+#include "windows.h"
+
 #ifndef OBJMGR_H
-#include"objmgr.h"
+#include "objmgr.h"
 #endif
 
 #ifndef TEAM_H
-#include"team.h"
+#include "team.h"
 #endif
 
 #ifndef COMNDR_H
-#include"comndr.h"
+#include "comndr.h"
 #endif
 
 #ifndef MISSIONGUI_H
-#include"missiongui.h"
+#include "missiongui.h"
 #endif
 
 #ifndef MECH_H
-#include"mech.h"
+#include "mech.h"
 #endif
 
 #ifndef MULTPLYR_H
-#include"multplyr.h"
+#include "multplyr.h"
 #endif
 
 #ifndef GAMESOUND_H
-#include"gamesound.h"
+#include "gamesound.h"
 #endif
 
 #ifndef PREFS_H
-#include"prefs.h"
+#include "prefs.h"
 #endif
 extern CPrefs prefs;
 
 #ifndef GAMECAM_H
-#include"gamecam.h"
+#include "gamecam.h"
 #endif
 
 #endif /*TEST_SHELL*/
 
 #ifndef SOUNDS_H
-#include"sounds.h"
+#include "sounds.h"
 #endif
 
 #ifndef MISSIONBEGIN_H
-#include"missionbegin.h"
+#include "missionbegin.h"
 #endif
 
 #ifndef MECHICON_H
-#include"mechicon.h"
+#include "mechicon.h"
 #endif
 
-#include"missionresults.h"
-#include"paths.h"
+#include "missionresults.h"
+#include "paths.h"
 
 extern bool quitGame;
 extern bool justStartMission;
@@ -81,365 +86,357 @@ extern float loadProgress;
 extern bool aborted;
 
 #include "../resource.h"
-void DEBUGWINS_print (const char* s, long window = 0);
+void DEBUGWINS_print(const char* s, long window = 0);
 
+#include "debugging.h"
+#include "cident.h"  // For FullPathFileName
 
 //----------------------------------------------------------------------------------
 //class Logistics
-Logistics *logistics = NULL;
+Logistics* logistics = NULL;
 
-
-		
 //----------------------------------------------------------------------------------
-void Logistics::destroy (void)
+void Logistics::destroy(void)
 {
-	delete missionBegin;
-	missionBegin = NULL;
+    delete missionBegin;
+    missionBegin = NULL;
 
-	delete missionResults;
-	missionResults = NULL;
+    delete missionResults;
+    missionResults = NULL;
 }	
-		
+
 //----------------------------------------------------------------------------------
-void Logistics::start (long startMode)
+void Logistics::start(long startMode)
 {
-	bMissionLoaded  = 0;
-	userInput->setMouseCursor( mState_LOGISTICS );
+    bMissionLoaded = 0;
+    userInput->setMouseCursor(mState_LOGISTICS);
 //	userInput->mouseOn();
 
-	DWORD localRenderer = prefs.renderer;
-	if (prefs.renderer != 0 && prefs.renderer != 3)
-		localRenderer = 0;
+    DWORD localRenderer = prefs.renderer;
+    if (prefs.renderer != 0 && prefs.renderer != 3)
+        localRenderer = 0;
 
-   	bool localFullScreen = prefs.fullScreen;
-   	bool localWindow = !prefs.fullScreen;
-   	if (Environment.fullScreen && prefs.fullScreen)
-   		localFullScreen = false;
+    bool localFullScreen = prefs.fullScreen;
+    bool localWindow = !prefs.fullScreen;
+    if (Environment.fullScreen && prefs.fullScreen)
+        localFullScreen = false;
 
-	switch (startMode)
-	{
-		case log_RESULTS: // pull out results later...
-			active = true;
-			//Heading back to logistics now.  Change screen back to 800x600
-			if (prefs.renderer == 3)
-				gos_SetScreenMode(800,600,16,0,0,0,true,localFullScreen,0,localWindow,0,localRenderer);
-			else
-				gos_SetScreenMode(800,600,16,prefs.renderer,0,0,0,localFullScreen,0,localWindow,0,localRenderer);
+    switch (startMode)
+    {
+        case log_RESULTS: // pull out results later...
+            active = true;
+            //Heading back to logistics now.  Change screen back to 800x600
+            if (prefs.renderer == 3)
+                gos_SetScreenMode(800, 600, 16, 0, 0, 0, true, localFullScreen, 0, localWindow, 0, localRenderer);
+            else
+                gos_SetScreenMode(800, 600, 16, prefs.renderer, 0, 0, 0, localFullScreen, 0, localWindow, 0, localRenderer);
 
-			lastMissionResult = scenarioResult;
-			if ( !missionResults )
-			{
-				LogisticsData::instance->init();
-				missionResults = new MissionResults;
-				missionResults->init();
-			}
+            lastMissionResult = scenarioResult;
+            if (!missionResults)
+            {
+                LogisticsData::instance->init();
+                missionResults = new MissionResults;
+                missionResults->init();
+            }
 
-			if ( scenarioResult == mis_PLAYER_WIN_BIG || MPlayer )
-			{
-				LogisticsData::instance->removeMechsInForceGroup();
-				if ( !MPlayer )
-					LogisticsData::instance->setMissionCompleted( );
+            if (scenarioResult == mis_PLAYER_WIN_BIG || MPlayer)
+            {
+                LogisticsData::instance->removeMechsInForceGroup();
+                if (!MPlayer)
+                    LogisticsData::instance->setMissionCompleted();
 
-				// if mission is over, play video then quit when  done
-				if ( LogisticsData::instance->campaignOver() && !MPlayer && !LogisticsData::instance->isSingleMission() )
-				{
-					mission->destroy();
-					playFullScreenVideo( LogisticsData::instance->getFinalVideo() );
-					setLogisticsState(log_SPLASH);
-					missionBegin->beginSplash();
-					userInput->mouseOn();
-					char tmp[256];
-					cLoadString( IDS_FINAL_MISSION, tmp, 255 );
-					FullPathFileName path;
-					path.init( savePath, tmp, ".fit" );
-					FitIniFile file;
-					file.create( path );
-					LogisticsData::instance->save(file);
-					active = true;
-				}
-				else if ( LogisticsData::instance->isSingleMission() && !MPlayer )
-				{
-					missionBegin->beginSplash();
-					logisticsState = log_SPLASH;
-				}
-				else
-				{
-			
-					missionResults->begin();
-					logisticsState = log_RESULTS;
-				}
+                // if mission is over, play video then quit when done
+                if (LogisticsData::instance->campaignOver() && !MPlayer && !LogisticsData::instance->isSingleMission())
+                {
+                    mission->destroy();
+                    playFullScreenVideo(LogisticsData::instance->getFinalVideo());
+                    setLogisticsState(log_SPLASH);
+                    missionBegin->beginSplash();
+                    userInput->mouseOn();
+                    char tmp[256];
+                    cLoadString(IDS_FINAL_MISSION, tmp, 255);
+                    FullPathFileName path;
+                    path.init(savePath, tmp, ".fit");
+                    FitIniFile file;
+                    file.create(path);
+                    LogisticsData::instance->save(file);
+                    active = true;
+                }
+                else if (LogisticsData::instance->isSingleMission() && !MPlayer)
+                {
+                    missionBegin->beginSplash();
+                    logisticsState = log_SPLASH;
+                }
+                else
+                {
+                    missionResults->begin();
+                    logisticsState = log_RESULTS;
+                }
+            }
+            else if (!justStartMission)
+            {
+                missionResults->bDone = true;
+                logisticsState = log_RESULTS;
+            }
+            else // end the game
+                quitGame = true;
 
-			}
-			else if ( !justStartMission )
-			{
-				missionResults->bDone = true;
-				logisticsState = log_RESULTS;
-			}
-			else // end the game
-				quitGame = true;
+            break;
+        case log_SPLASH:
+        {
+            if (aborted) {
+                if (prefs.renderer == 3)
+                    gos_SetScreenMode(800, 600, 16, 0, 0, 0, true, localFullScreen, 0, localWindow, 0, localRenderer);
+                else
+                    gos_SetScreenMode(800, 600, 16, prefs.renderer, 0, 0, 0, localFullScreen, 0, localWindow, 0, localRenderer);
 
-			break;
-		case log_SPLASH:
-		{
-			if (aborted) {
-				if (prefs.renderer == 3)
-					gos_SetScreenMode(800,600,16,0,0,0,true,localFullScreen,0,localWindow,0,localRenderer);
-				else
-					gos_SetScreenMode(800,600,16,prefs.renderer,0,0,0,localFullScreen,0,localWindow,0,localRenderer);
+                if (missionBegin)
+                    missionBegin->beginSplash();
 
-				if ( missionBegin )
-					missionBegin->beginSplash();
+                if (MPlayer)
+                {
+                    delete MPlayer;
+                    MPlayer = NULL;
+                }
+            }
+            
+            initializeLogData();
+            
+            bool bTestScript = false;
+            if (bTestScript)
+            {
+                FitIniFile loadFile;
+                loadFile.open("data" PATH_SEPARATOR "missions" PATH_SEPARATOR "save.fit");
+                LogisticsData::instance->load(loadFile);
+                FitIniFile saveFile;
+                saveFile.open("data" PATH_SEPARATOR "missions" PATH_SEPARATOR "save.fit", CREATE);
+                LogisticsData::instance->save(saveFile);
+            }
 
-				if ( MPlayer )
-				{
-					delete MPlayer;
-					MPlayer = NULL;
-				}
-			}
-			
-			initializeLogData();
-			
-			bool bTestScript = false;
-			if ( bTestScript )
-			{
-				FitIniFile loadFile;
-				loadFile.open( "data" PATH_SEPARATOR "missions" PATH_SEPARATOR "save.fit" );
-				LogisticsData::instance->load( loadFile );
-				FitIniFile saveFile;
-				saveFile.open("data" PATH_SEPARATOR "missions" PATH_SEPARATOR "save.fit", CREATE);
-				LogisticsData::instance->save( saveFile );
-		
-			}
+            active = TRUE;
+            setLogisticsState(log_SPLASH);
 
-			active = TRUE;
-			setLogisticsState(log_SPLASH);
+            if (!missionBegin)
+            {
+                missionBegin = new MissionBegin;
+                missionBegin->beginSplash();
+                missionBegin->init();
+            }
+        }
+        break;
 
-			if ( !missionBegin )
-			{
-				missionBegin = new MissionBegin;
-				missionBegin->beginSplash();
-				missionBegin->init();
-			}
+        case log_ZONE:
+        {
+            logisticsData.init();
+            if (!missionBegin)
+            {
+                missionBegin = new MissionBegin;
+                missionBegin->init();
+            }
 
-		}
-		break;
-
-		case log_ZONE:
-		{
-			logisticsData.init();
-			if ( !missionBegin )
-			{
-				missionBegin = new MissionBegin;
-				missionBegin->init();
-			}
-
-			missionBegin->beginZone();
-			active = TRUE;
-			setLogisticsState( log_SPLASH );
-			userInput->mouseOn();
-			userInput->setMouseCursor( mState_NORMAL );
-
-		}
-		break;
-	}
+            missionBegin->beginZone();
+            active = TRUE;
+            setLogisticsState(log_SPLASH);
+            userInput->mouseOn();
+            userInput->setMouseCursor(mState_NORMAL);
+        }
+        break;
+    }
 }	
 
 //----------------------------------------------------------------------------------
-void Logistics::stop (void)
+void Logistics::stop(void)
 {
-	switch (prevState)
-	{
-		case log_SPLASH:
-			break;
-			
-		case log_RESULTS:
-			break;
-	}
-		
-	active = FALSE;
+    switch (prevState)
+    {
+        case log_SPLASH:
+            break;
+            
+        case log_RESULTS:
+            break;
+    }
+        
+    active = FALSE;
 }	
 
 //----------------------------------------------------------------------------------
-long Logistics::update (void)
+long Logistics::update(void)
 {
-	//MUST do this every frame.  The movie movies will play wrong, otherwise!!
+    //MUST do this every frame.  The movie movies will play wrong, otherwise!!
+    if (bMovie)
+    {
+        userInput->mouseOff();
+        if (userInput->getKeyDown(KEY_SPACE) || userInput->getKeyDown(KEY_ESCAPE) || userInput->getKeyDown(KEY_LMOUSE))
+        {
+            bMovie->stop();
+        }
 
-	if ( bMovie )
-	{
-		userInput->mouseOff();
-		if (userInput->getKeyDown(KEY_SPACE) || userInput->getKeyDown(KEY_ESCAPE) || userInput->getKeyDown(KEY_LMOUSE))
-		{
-			bMovie->stop();
-		}
+        bMovie->update();
+        if (bMovie)
+        {
+            if (LogisticsData::instance->campaignOver() && (S_strnicmp(bMovie->getMovieName().c_str(), "credits", 7) == 0))
+            {
+                missionBegin->beginSplash();
+            }
 
-		bool result = bMovie->update();
-		if (result)
-		{
-			if ( LogisticsData::instance->campaignOver() && (S_strnicmp(bMovie->getMovieName(),"credits",7) == 0) )
-			{
-				missionBegin->beginSplash();
-			}
+            //Check if we are cinema5.  If we are, spool up the credits and play those.
+            // Otherwise, same as before Mr. Sulu.  Stay with him...
+            if (S_strnicmp(bMovie->getMovieName().c_str(), "cinema5", 7) == 0)
+            {
+                //OLD Movie's Over.
+                //Whack it.
+                delete bMovie;
+                bMovie = NULL;
 
-			//Check if we are cinema5.  If we are, spool up the credits and play those.
-			// Otherwise, same as before Mr. Sulu.  Stay with him...
-			if (S_strnicmp(bMovie->getMovieName(),"cinema5",7) == 0)
-			{
-				//OLD Movie's Over.
-				//Whack it.
-				delete bMovie;
-				bMovie = NULL;
+                FullPathFileName movieName;
+                //path.init(moviePath, "credits", ".bik");
+                movieName.init(moviePath, "credits", ".mp4");
 
-				FullPathFileName path;
-				path.init( moviePath, "credits", ".bik" );
+                RECT movieRect;
+                movieRect.top = 0;
+                movieRect.left = 0;
+                movieRect.right = Environment.screenWidth;
+                movieRect.bottom = 600;
 
-				RECT movieRect;
-				movieRect.top = 0;
-				movieRect.left = 0;
-				movieRect.right = Environment.screenWidth;
-				movieRect.bottom = 600;
+                SDL_Window* gameWindow = SDL_GL_GetCurrentWindow();
+                SDL_GLContext gameContext = SDL_GL_GetCurrentContext();
+                bMovie = new MP4Player(std::string(movieName), gameWindow, gameContext);
+                // Note: Using Windows RECT breaks cross-platform compatibility for now.
+                RECT convertedRect = {movieRect.left, movieRect.top, movieRect.right, movieRect.bottom};
+                bMovie->init((const char*)movieName, convertedRect, true, gameWindow, gameContext);
+                soundSystem->playDigitalMusic(33);
+            }
+            else
+            {
+                //Movie's Over.
+                //Whack it.
+                delete bMovie;
+                bMovie = NULL;
 
-				bMovie = new MC2Movie;
-				bMovie->init(path,movieRect,true);
-				soundSystem->playDigitalMusic(33);
-			}
-			else
-			{
-				//Movie's Over.
-				//Whack it.
-				delete bMovie;
-				bMovie = NULL;
+                soundSystem->playDigitalMusic(LogisticsData::instance->getCurrentMissionTune());
+                userInput->mouseOn(); // No assignment to bool
+            }
+        }
 
-				soundSystem->playDigitalMusic(LogisticsData::instance->getCurrentMissionTune());
-				userInput->mouseOn();	
-			}
-		}
+        return logisticsState;
+    }
 
-		return logisticsState;
-	}
+    //Don't keep setting the mouse cursor to logistics cursor during mission!!
+    if (!mission->isActive())
+        userInput->setMouseCursor(mState_LOGISTICS);
+    //Stop doing this every frame.  ONLY turn it on when we need to!!
 
-	//Don't keep setting the mouse cursor to logistics cursor during mission!!
-	if (!mission->isActive())
-		userInput->setMouseCursor( mState_LOGISTICS );
-	//Stop doing this every frame.  ONLY turn it on when we need to!!
+    if (logisticsState == log_RESULTS)
+    {
+        if (missionResults)
+            missionResults->update();
 
-	if ( logisticsState == log_RESULTS )
-	{
-		if ( missionResults )
-			missionResults->update();
+        if (missionResults->isDone())
+        {
+            missionResults->end();
+            if (!justStartMission && !MPlayer)
+            {
+                logisticsState = log_SPLASH;
+                if (!missionBegin)
+                {
+                    missionBegin = new MissionBegin();
+                    missionBegin->init();
+                }
+                
+                missionBegin->begin();
 
-		if ( missionResults->isDone() )
-		{
-			missionResults->end();
-			if ( !justStartMission && !MPlayer )
-			{
-					logisticsState = log_SPLASH;
-					if ( !missionBegin )
-					{
-						missionBegin = new MissionBegin();
-						missionBegin->init( );
-					}
-					
-					missionBegin->begin();
+                if (lastMissionResult == mis_PLAYER_LOST_BIG && !MPlayer)
+                {
+                    if (LogisticsData::instance->skipLogistics())
+                    {
+                        if (LogisticsData::instance->showChooseMission())
+                            missionBegin->begin();
+                        else
+                            missionBegin->beginSplash();
+                    }
+                    else
+                        missionBegin->setToMissionBriefing();
+                }
+                else
+                {
+                    const char* videoName = LogisticsData::instance->getCurrentBigVideo();
+                    if (videoName)
+                    {
+                        playFullScreenVideo(videoName);
+                    }
+                }
+            }
+            else if (MPlayer)
+            {
+                logisticsState = log_SPLASH;
+                if (!missionBegin)
+                {
+                    missionBegin = new MissionBegin();
+                    missionBegin->init();
+                }
 
- 					if ( lastMissionResult == mis_PLAYER_LOST_BIG && !MPlayer )
-					{
-						if ( LogisticsData::instance->skipLogistics()  )
-						{
-							if ( LogisticsData::instance->showChooseMission() )
-								missionBegin->begin();
+                if (MPlayer->hostLeft || MPlayer->commanderID < 0)
+                {
+                    missionBegin->beginSplash(NULL);
+                    MPlayer->closeSession();
+                }
+                else
+                    missionBegin->restartMPlayer(NULL);
+            }
+            else
+                quitGame = true;
+        }
+    }
+    //Used to start mission from command line, bypassing logistics
+    else if (logisticsState == log_STARTMISSIONFROMCMDLINE)
+    {
+    }
+    else if (logisticsState != log_DONE)
+    {
+        if (missionBegin)
+        {
+            const char* pVid = missionBegin->update();
+            if (pVid && (0 != strcmp("", pVid)))
+            {
+                playFullScreenVideo(pVid);
+                return logisticsState;
+            }
+            if (missionBegin->readyToLoad() && !bMissionLoaded)
+            {
+                missionBegin->end();	//Called to clean up ABL!!
 
-							else
-								missionBegin->beginSplash();
-						}
-						else
-							missionBegin->setToMissionBriefing();
-					}
-					else
-					{
-						const char* videoName = LogisticsData::instance->getCurrentBigVideo();
+                lastMissionResult = 0;
 
-						if ( videoName )
-						{
-							playFullScreenVideo( videoName );
-						}
-					}
-				
-			}
-			else if ( MPlayer )
-			{
-				logisticsState = log_SPLASH;
-				if ( !missionBegin )
-				{
-					missionBegin = new MissionBegin();
-					missionBegin->init( );
-				}
+                if (!beginMission(0, 0, 0)) {
+                    missionBegin->beginAtConnectionScreen();
+                    return(logisticsState);
+                }
+                bMissionLoaded = true;
+            }
+            if (missionBegin->isDone())
+            {				
+                logisticsState = log_DONE;
+            }
+        }
+    }
 
-				if ( MPlayer->hostLeft || MPlayer->commanderID < 0 )
-				{
-					missionBegin->beginSplash( NULL );
-					MPlayer->closeSession();
-				}
-				else
-					missionBegin->restartMPlayer(NULL);
-
-
-				
-			}
-			else
-				quitGame = true;
-		}
-	}
-	//Used to start mission from command line, bypassing logistics
-	else if (logisticsState == log_STARTMISSIONFROMCMDLINE)
-	{
-		
-	}
-	else if ( logisticsState != log_DONE )
-	{
-		if ( missionBegin )
-		{
-			const char* pVid =  missionBegin->update();
-			if ( pVid && (0 != strcmp("", pVid)) )
-			{
-				playFullScreenVideo( pVid );
-				return logisticsState;
-			}
-			if ( missionBegin->readyToLoad() && !bMissionLoaded )
-			{
-				missionBegin->end();	//Called to clean up ABL!!
-
-				lastMissionResult = 0;
-
-				if (!beginMission(0, 0, 0)) {
-					missionBegin->beginAtConnectionScreen();
-					return(logisticsState);
-				}
-				bMissionLoaded = true;
-			}
-			if ( missionBegin->isDone() )
-			{				
-				logisticsState = log_DONE;
-			}
-		}
-	}
-
-	return(logisticsState);
+    return(logisticsState);
 }	
-		
+
 //----------------------------------------------------------------------------------
-void Logistics::render (void)
+void Logistics::render(void)
 {
-	if (bMovie)
-	{
-		bMovie->render();
-	}
-	else if ( active )
-	{
-		if ( logisticsState == log_RESULTS )
-			missionResults->render();
-		else if ( logisticsState == log_SPLASH && missionBegin )
-			missionBegin->render();
-	}
+    if (bMovie)
+    {
+        bMovie->render();
+    }
+    else if (active)
+    {
+        if (logisticsState == log_RESULTS)
+            missionResults->render();
+        else if (logisticsState == log_SPLASH && missionBegin)
+            missionBegin->render();
+    }
 }
 
 //-----------------------------------------------------------------------------
@@ -449,459 +446,441 @@ extern unsigned int MultiPlayCommanderId;
 
 int _stdcall Logistics::beginMission(void*, int, void*[])
 {
+    if (MPlayer)
+        MPlayer->setMode(MULTIPLAYER_MODE_LOADING);
 
-	if (MPlayer)
-		MPlayer->setMode(MULTIPLAYER_MODE_LOADING);
+    char commandersToLoad[MAX_MC_PLAYERS][3] = {{0, 0, 0}, {1, 1, 1}, {2, 2, 2}, {3, 3, 3}, {4, 4, 4}, {5, 5, 5}, {6, 6, 6}, {7, 7, 7}};
+    long missionLoadType = LogisticsData::instance->skipLogistics() ? 
+                            MISSION_LOAD_SP_QUICKSTART : MISSION_LOAD_SP_LOGISTICS;
+    if (MPlayer) {
+        //---------------------------
+        // Calc valid commanderIDs...
+        long curCommanderID = 0;
+        for (long CID = 0; CID < MAX_MC_PLAYERS; CID++) {
+            MPlayer->availableCIDs[CID] = true;
+            if (MPlayer->playerInfo[CID].player && (MPlayer->playerInfo[CID].commanderID > -1)) {
+                if (CID != curCommanderID) {
+                    long oldCommanderID = CID;
+                    MPlayer->playerInfo[CID].commanderID = curCommanderID;
+                    memcpy(&MPlayer->playerInfo[curCommanderID], &MPlayer->playerInfo[CID], sizeof(MC2Player));
+                    MPlayer->playerInfo[CID].player = NULL;
+                    MPlayer->playerInfo[CID].commanderID = -1;
+                    for (long j = 0; j < MAX_MC_PLAYERS; j++)
+                        if (MPlayer->playerList[j].player == MPlayer->playerInfo[curCommanderID].player)
+                            MPlayer->playerList[j].commanderID = curCommanderID;
+                    if (oldCommanderID == MPlayer->commanderID)
+                        MPlayer->commanderID = curCommanderID;
+                }
+                MPlayer->availableCIDs[curCommanderID] = false;
+                curCommanderID++;
+            }
+        }
+        //----------------------
+        // Calc valid teamIDs...
+        long curTeamID = 0;
+        for (long teamID = 0; teamID < MAX_MC_PLAYERS; teamID++) {
+            bool teamFound = false;
+            for (long i = 0; i < MAX_MC_PLAYERS; i++)
+                if (MPlayer->playerInfo[i].player && (MPlayer->playerInfo[i].team == teamID)) {
+                    MPlayer->playerInfo[i].team = curTeamID;
+                    teamFound = true;
+                }
+            if (teamFound)
+                curTeamID++;
+        }
+        if (MPlayer->isHost()) {
+            // Determine drop zone order here...
+            char dropZoneList[8];
+            char hqs[MAX_TEAMS];
+            if (MPlayer->missionSettings.missionType == MISSION_TYPE_OTHER) {
+                bool goodToLoad = mission->calcComplexDropZones((char*)(const char*)LogisticsData::instance->getCurrentMission(), dropZoneList);
+                if (!goodToLoad)
+                    STOP(("Logisitics.beginMission: teams do not match up for complex mission"));
+                for (long i = 0; i < MAX_TEAMS; i++)
+                    hqs[i] = i;
+            }
+            else
+                MPlayer->calcDropZones(dropZoneList, hqs);
+            if (MPlayer->missionSettings.quickStart)
+                for (long i = 0; i < MAX_MC_PLAYERS; i++) {
+                    MPlayer->commandersToLoad[i][0] = (long)dropZoneList[i]; //MPlayer->playerInfo[i].commanderID;
+                    MPlayer->commandersToLoad[i][1] = (long)(dropZoneList[i] > -1) ? MPlayer->playerInfo[dropZoneList[i]].team : 0;
+                    MPlayer->commandersToLoad[i][2] = hqs[i];
+                }
+            else
+                for (long i = 0; i < MAX_MC_PLAYERS; i++) {
+                    MPlayer->commandersToLoad[i][0] = dropZoneList[i]; //-1;
+                    MPlayer->commandersToLoad[i][1] = (dropZoneList[i] > -1) ? MPlayer->playerInfo[dropZoneList[i]].team : 0; //-1;
+                    MPlayer->commandersToLoad[i][2] = hqs[i];
+                }
+            MPlayer->sendMissionSetup(0, 0, NULL);
+        }
+        if (!MPlayer->waitTillStartLoading()) {
+            // SERVER DROPPED
+            return(0);
+        }
+        if (MPlayer->commandersToLoad[0][0] < -1)
+            PAUSE(("Logistics.beginMission: bad commandersToLoad"));
+        for (long i = 0; i < MAX_MC_PLAYERS; i++) {
+            commandersToLoad[i][0] = MPlayer->commandersToLoad[i][0];
+            commandersToLoad[i][1] = MPlayer->commandersToLoad[i][1];
+            commandersToLoad[i][2] = MPlayer->commandersToLoad[i][2];
+        }
+        if (MPlayer->missionSettings.quickStart) {
+            MultiPlayTeamId = MPlayer->playerInfo[MPlayer->commanderID].team;
+            //if (MultiPlayTeamId < 0)
+            if (MultiPlayTeamId == 0xffffffff)
+                STOP(("Bad commanderID"));
+            MultiPlayCommanderId = MPlayer->commanderID;
+            //if (MultiPlayCommanderId < 0)
+            if (MultiPlayCommanderId == 0xffffffff)
+                STOP(("Bad commanderID"));
+            missionLoadType = MISSION_LOAD_MP_QUICKSTART;
+        }
+        else {
+            MultiPlayTeamId = MPlayer->playerInfo[MPlayer->commanderID].team;
+            MultiPlayCommanderId = MPlayer->commanderID;
+            missionLoadType = MISSION_LOAD_MP_LOGISTICS;
+        }
+        long maxTeam = -1;
+        for (int i = 0; i < MAX_MC_PLAYERS; i++)
+            if (MPlayer->playerInfo[i].team > maxTeam)
+                maxTeam = MPlayer->playerInfo[i].team;
+        MPlayer->numTeams = maxTeam + 1;
+    }
+    else if (missionLoadType == MISSION_LOAD_SP_LOGISTICS) {
+        commandersToLoad[0][0] = -1;
+        commandersToLoad[0][1] = -1;
+        commandersToLoad[0][2] = -1;
+    }
+    else {
+        commandersToLoad[0][0] = 0;
+        commandersToLoad[0][1] = 0;
+        commandersToLoad[0][2] = -1;
+    }
 
-	char commandersToLoad[MAX_MC_PLAYERS][3] = {{0, 0, 0}, {1, 1, 1}, {2, 2, 2}, {3, 3, 3}, {4, 4, 4}, {5, 5, 5}, {6, 6, 6}, {7, 7, 7}};
-	long missionLoadType = LogisticsData::instance->skipLogistics() ? 
-							MISSION_LOAD_SP_QUICKSTART : MISSION_LOAD_SP_LOGISTICS;
-	if (MPlayer) {
-		//---------------------------
-		// Calc valid commanderIDs...
-		long curCommanderID = 0;
-		for (long CID = 0; CID < MAX_MC_PLAYERS; CID++) {
-			MPlayer->availableCIDs[CID] = true;
-			if (MPlayer->playerInfo[CID].player && (MPlayer->playerInfo[CID].commanderID > -1)) {
-				if (CID != curCommanderID) {
-					long oldCommanderID = CID;
-					MPlayer->playerInfo[CID].commanderID = curCommanderID;
-					memcpy(&MPlayer->playerInfo[curCommanderID], &MPlayer->playerInfo[CID], sizeof(MC2Player));
-					MPlayer->playerInfo[CID].player = NULL;
-					MPlayer->playerInfo[CID].commanderID = -1;
-					for (long j = 0; j < MAX_MC_PLAYERS; j++)
-						if (MPlayer->playerList[j].player == MPlayer->playerInfo[curCommanderID].player)
-							MPlayer->playerList[j].commanderID = curCommanderID;
-					if (oldCommanderID == MPlayer->commanderID)
-						MPlayer->commanderID = curCommanderID;
-				}
-				MPlayer->availableCIDs[curCommanderID] = false;
-				curCommanderID++;;
-			}
-		}
-		//----------------------
-		// Calc valid teamIDs...
-		long curTeamID = 0;
-		for (long teamID = 0; teamID < MAX_MC_PLAYERS; teamID++) {
-			bool teamFound = false;
-			for (long i = 0; i < MAX_MC_PLAYERS; i++)
-				if (MPlayer->playerInfo[i].player && (MPlayer->playerInfo[i].team == teamID)) {
-					MPlayer->playerInfo[i].team = curTeamID;
-					teamFound = true;
-				}
-			if (teamFound)
-				curTeamID++;
-		}
-		if (MPlayer->isHost()) {
-			// Determine drop zone order here...
-			char dropZoneList[8];
-			char hqs[MAX_TEAMS];
-			if (MPlayer->missionSettings.missionType == MISSION_TYPE_OTHER) {
-				bool goodToLoad = mission->calcComplexDropZones((char*)(const char*)LogisticsData::instance->getCurrentMission(), dropZoneList);
-				if (!goodToLoad)
-					STOP(("Logisitics.beginMission: teams do not match up for complex mission"));
-				for (long i = 0; i < MAX_TEAMS; i++)
-					hqs[i] = i;
-				}
-			else
-				MPlayer->calcDropZones(dropZoneList, hqs);
-			if (MPlayer->missionSettings.quickStart)
-				for (long i = 0; i < MAX_MC_PLAYERS; i++) {
-					MPlayer->commandersToLoad[i][0] = (long)dropZoneList[i]; //MPlayer->playerInfo[i].commanderID;
-					MPlayer->commandersToLoad[i][1] = (long)(dropZoneList[i] > -1) ? MPlayer->playerInfo[dropZoneList[i]].team : 0;
-					MPlayer->commandersToLoad[i][2] = hqs[i];
-				}
-			else
-				for (long i = 0; i < MAX_MC_PLAYERS; i++) {
-					MPlayer->commandersToLoad[i][0] = dropZoneList[i]; //-1;
-					MPlayer->commandersToLoad[i][1] = (dropZoneList[i] > -1) ? MPlayer->playerInfo[dropZoneList[i]].team : 0; //-1;
-					MPlayer->commandersToLoad[i][2] = hqs[i];
-				}
-			MPlayer->sendMissionSetup(0, 0, NULL);
-		}
-		if (!MPlayer->waitTillStartLoading()) {
-			// SERVER DROPPED
-			return(0);
-		}
-		if (MPlayer->commandersToLoad[0][0] < -1)
-			PAUSE(("Logistics.beginMission: bad commandersToLoad"));
-		for (long i = 0; i < MAX_MC_PLAYERS; i++) {
-			commandersToLoad[i][0] = MPlayer->commandersToLoad[i][0];
-			commandersToLoad[i][1] = MPlayer->commandersToLoad[i][1];
-			commandersToLoad[i][2] = MPlayer->commandersToLoad[i][2];
-		}
-		if (MPlayer->missionSettings.quickStart) {
-			MultiPlayTeamId = MPlayer->playerInfo[MPlayer->commanderID].team;
-			//if (MultiPlayTeamId < 0)
-			if (MultiPlayTeamId == 0xffffffff)
-				STOP(("Bad commanderID"));
-			MultiPlayCommanderId = MPlayer->commanderID;
-			//if (MultiPlayCommanderId < 0)
-			if (MultiPlayCommanderId == 0xffffffff)
-				STOP(("Bad commanderID"));
-			missionLoadType = MISSION_LOAD_MP_QUICKSTART;
-			}
-		else {
-			MultiPlayTeamId = MPlayer->playerInfo[MPlayer->commanderID].team;
-			MultiPlayCommanderId = MPlayer->commanderID;
-			missionLoadType = MISSION_LOAD_MP_LOGISTICS;
-		}
-		long maxTeam = -1;
-		for (int i = 0; i < MAX_MC_PLAYERS; i++)
-			if (MPlayer->playerInfo[i].team > maxTeam)
-				maxTeam = MPlayer->playerInfo[i].team;
-		MPlayer->numTeams = maxTeam + 1;
-		}
-	else if (missionLoadType == MISSION_LOAD_SP_LOGISTICS) {
-		commandersToLoad[0][0] = -1;
-		commandersToLoad[0][1] = -1;
-		commandersToLoad[0][2] = -1;
-	}
-	else {
-		commandersToLoad[0][0] = 0;
-		commandersToLoad[0][1] = 0;
-		commandersToLoad[0][2] = -1;
-	}
+    if (mission)
+        mission->destroy();
 
-	if (mission)
-		mission->destroy();
+    long numPlayers = 1;
+    if (MPlayer)
+        MPlayer->getPlayers(numPlayers);
+    long numMoversPerCommander[MAX_MC_PLAYERS] = {12, 12, 12, 9, 7, 6, 5, 4};
+    Stuff::Vector3D dropZoneList[255]; // ubsurdly large, but sometimes we overrun this.
+    long dropZoneID = 0;
+    if (MPlayer) {
+        //dropZoneID = MPlayer->commanderID;
+        for (long i = 0; i < MAX_MC_PLAYERS; i++)
+            if (commandersToLoad[i][0] == MPlayer->commanderID) {
+                dropZoneID = i;
+                break;
+            }
+        useUnlimitedAmmo = MPlayer->missionSettings.unlimitedAmmo;
+    }
 
-	long numPlayers = 1;
-	if ( MPlayer )
-		MPlayer->getPlayers(numPlayers);
-	long numMoversPerCommander[MAX_MC_PLAYERS] = {12, 12, 12, 9, 7, 6, 5, 4};
-	Stuff::Vector3D dropZoneList[255]; // ubsurdly large, but sometimes we overrun this.
-	long dropZoneID = 0;
-	if (MPlayer) {
-		//dropZoneID = MPlayer->commanderID;
-		for (long i = 0; i < MAX_MC_PLAYERS; i++)
-			if (commandersToLoad[i][0] == MPlayer->commanderID) {
-				dropZoneID = i;
-				break;
-			}
-		useUnlimitedAmmo = MPlayer->missionSettings.unlimitedAmmo;
-	}
+    mission->init((char*)(const char*)LogisticsData::instance->getCurrentMission(), missionLoadType, dropZoneID, dropZoneList, commandersToLoad, numMoversPerCommander[numPlayers - 1]);
 
-	mission->init((char*)(const char*)LogisticsData::instance->getCurrentMission(), missionLoadType, dropZoneID, dropZoneList, commandersToLoad, numMoversPerCommander[numPlayers - 1]);
+    LogisticsData::instance->rpJustAdded = 0;
 
-	LogisticsData::instance->rpJustAdded = 0;
+    if (MPlayer) {
+        if (missionLoadType == MISSION_LOAD_MP_LOGISTICS) {
+            EList<LogisticsMech*, LogisticsMech*> list;
+            LogisticsData::instance->getForceGroup(list);
 
-	if (MPlayer) {
-		if (missionLoadType == MISSION_LOAD_MP_LOGISTICS) {
-			EList< LogisticsMech*, LogisticsMech* > list;
-			LogisticsData::instance->getForceGroup(list);
+            long dropZoneIndex = 0;
+            long numMechs = 0;
+            for (EList<LogisticsMech*, LogisticsMech*>::EIterator iter = list.Begin(); !iter.IsDone(); iter++) {
+                numMechs++;
+                if (!(*iter)->getPilot())
+                    continue;
+                CompressedMech mechData;
+                mechData.lastMech = (list.Count() == numMechs);
+                mechData.objNumber = (*iter)->getFitID();
+                mechData.commanderID = MPlayer->commanderID;
+                mechData.baseColor = MPlayer->colors[MPlayer->playerInfo[MPlayer->commanderID].baseColor[BASECOLOR_TEAM]];
+                mechData.highlightColor1 = MPlayer->colors[MPlayer->playerInfo[MPlayer->commanderID].stripeColor];
+                mechData.highlightColor2 = MPlayer->colors[MPlayer->playerInfo[MPlayer->commanderID].stripeColor];
+                strcpy(mechData.pilotFile, (*iter)->getPilot()->getFileName());
+                strcpy(mechData.mechFile, (*iter)->getFileName());
+                strcpy(mechData.variantName, (*iter)->getName());
+                mechData.variantNum = (*iter)->getVariant()->getFileID();
+                mechData.cBills = (*iter)->getVariant()->getCost();
+                mechData.pos[0] = dropZoneList[dropZoneIndex].x;
+                mechData.pos[1] = dropZoneList[dropZoneIndex++].y;
+                mechData.designerMech = (*iter)->getVariant()->isDesignerMech();
+                mechData.numComponents = (*iter)->getComponentCount();
+                if (mechData.numComponents)	{
+                    long* componentList = (long*)systemHeap->Malloc(sizeof(long) * mechData.numComponents);
+                    long otherCount = mechData.numComponents;
+                    (*iter)->getComponents(otherCount, componentList);
+                    if (otherCount != mechData.numComponents)
+                        STOP(("Heidi's getComponentCount does not agree with count returned from getComponents"));
+                    for (long i = 0; i < mechData.numComponents; i++)
+                        mechData.components[i] = (unsigned char)componentList[i];
+                }
+                MPlayer->sendMissionSetup(0, 1, &mechData);
+            }
 
-			long dropZoneIndex = 0;
-			long numMechs = 0;
-			for (EList< LogisticsMech*, LogisticsMech* >::EIterator iter = list.Begin(); !iter.IsDone(); iter++) {
-				numMechs++;
-				if ( !(*iter)->getPilot() )
-					continue;
-				CompressedMech mechData;
-				mechData.lastMech = (list.Count() == numMechs);
-				mechData.objNumber =  (*iter)->getFitID();
-				mechData.commanderID = MPlayer->commanderID;
-				mechData.baseColor = MPlayer->colors[MPlayer->playerInfo[MPlayer->commanderID].baseColor[BASECOLOR_TEAM]];
-				mechData.highlightColor1 = MPlayer->colors[MPlayer->playerInfo[MPlayer->commanderID].stripeColor];
-				mechData.highlightColor2 = MPlayer->colors[MPlayer->playerInfo[MPlayer->commanderID].stripeColor];
-				strcpy(mechData.pilotFile, (*iter)->getPilot()->getFileName());
-				strcpy(mechData.mechFile, (*iter)->getFileName());
-				strcpy(mechData.variantName, (*iter)->getName());
-				mechData.variantNum = (*iter)->getVariant()->getFileID();
-				mechData.cBills = (*iter)->getVariant()->getCost();
-				mechData.pos[0] = dropZoneList[dropZoneIndex].x;
-				mechData.pos[1] = dropZoneList[dropZoneIndex++].y;
-				mechData.designerMech = (*iter)->getVariant()->isDesignerMech();
-				mechData.numComponents = (*iter)->getComponentCount();
-				if (mechData.numComponents)	{
-					long* componentList = (long*)systemHeap->Malloc(sizeof(long) * mechData.numComponents);
-					long otherCount = mechData.numComponents;
-					(*iter)->getComponents(otherCount, componentList);
-					if (otherCount != mechData.numComponents)
-						STOP(("Heidi's getComponentCount does not agree with count returned from getComponents"));
-					for (long i = 0; i < mechData.numComponents; i++)
-						mechData.components[i] = (unsigned char)componentList[i];
-				}
-				MPlayer->sendMissionSetup(0, 1, &mechData);
-			}
+            if (!MPlayer->waitTillMechDataReceived()) {
+                // SERVER DROPPED
+                mission->destroy();
+                return(0);
+            }
+    
+            ObjectManager->numMechs = 0;
+            ObjectManager->numVehicles = 0;
+            for (long i = 0; i < MAX_MC_PLAYERS; i++) {
+                if (MPlayer->mechDataReceived[i]) {
+                    for (long j = 0; j < 12; j++) {
+                        if (MPlayer->mechData[i][j].objNumber > -1) {
+                            MoverInitData data;
+                            memset(&data, 0, sizeof(MoverInitData));
+                            data.objNumber = MPlayer->mechData[i][j].objNumber;
+                            data.rosterIndex = 255;
+                            data.controlType = 2;
+                            data.controlDataType = 1;
+                            data.position.x = MPlayer->mechData[i][j].pos[0];
+                            data.position.y = MPlayer->mechData[i][j].pos[1];
+                            data.position.z = 0.0;
+                            data.rotation = 0;
+                            data.teamID = MPlayer->playerInfo[MPlayer->mechData[i][j].commanderID].team;
+                            data.commanderID = MPlayer->mechData[i][j].commanderID;
+                            data.baseColor = MPlayer->mechData[i][j].baseColor;
+                            data.highlightColor1 = MPlayer->mechData[i][j].highlightColor1;
+                            data.highlightColor2 = MPlayer->mechData[i][j].highlightColor2;
+                            data.gestureID = 2;
+                            data.active = 1;
+                            data.exists = 1;
+                            data.capturable = 0;
+                            data.icon = 0;
+                            
+                            strcpy(data.pilotFileName, MPlayer->mechData[i][j].pilotFile);
+                            strcpy(data.brainFileName, "pbrain");
+                            strcpy(data.csvFileName, MPlayer->mechData[i][j].mechFile);
+                            data.numComponents = MPlayer->mechData[i][j].numComponents;
+                            for (long k = 0; k < MPlayer->mechData[i][j].numComponents; k++)
+                                data.components[k] = MPlayer->mechData[i][j].components[k];
+                            long moverHandle = mission->addMover(&data);
+                            if (moverHandle < 1)
+                                STOP(("Logistics.beginMission: unable to addMover"));
+                            MoverPtr mover = (MoverPtr)ObjectManager->get(moverHandle);
+                            if (!mover)
+                                STOP(("Logistics.beginMission: NULL mover"));
+                            if (mover->getObjectClass() != BATTLEMECH)
+                                STOP(("Logistics.beginMission: not a mech"));
+                            ((BattleMech*)mover)->cBills = MPlayer->mechData[i][j].cBills;
+                            strcpy(((BattleMech*)mover)->variantName, MPlayer->mechData[i][j].variantName);
+                            data.variant = MPlayer->mechData[i][j].variantNum;
+                        }
+                    }
+                }
+            }
+        }
+        else // gotta update pilot availability
+        {
+            long count = 256;
+            LogisticsPilot* pilots[256];
+            LogisticsData::instance->getPilots(pilots, count);
 
-			if (!MPlayer->waitTillMechDataReceived()) {
-				// SERVER DROPPED
-				mission->destroy();
-				return(0);
-			}
-	
-			ObjectManager->numMechs = 0;
-			ObjectManager->numVehicles = 0;
-			for (long i = 0; i < MAX_MC_PLAYERS; i++) {
-				if (MPlayer->mechDataReceived[i]) {
-					for (long j = 0; j < 12; j++) {
-						if (MPlayer->mechData[i][j].objNumber > -1) {
-							MoverInitData data;
-							memset(&data, 0, sizeof(MoverInitData));
-							data.objNumber = MPlayer->mechData[i][j].objNumber;
-							data.rosterIndex = 255;
-							data.controlType = 2;
-							data.controlDataType = 1;
-							data.position.x = MPlayer->mechData[i][j].pos[0];
-							data.position.y = MPlayer->mechData[i][j].pos[1];
-							data.position.z = 0.0;
-							data.rotation = 0;
-							data.teamID = MPlayer->playerInfo[MPlayer->mechData[i][j].commanderID].team;
-							data.commanderID = MPlayer->mechData[i][j].commanderID;
-							data.baseColor = MPlayer->mechData[i][j].baseColor;
-							data.highlightColor1 = MPlayer->mechData[i][j].highlightColor1;
-							data.highlightColor2 = MPlayer->mechData[i][j].highlightColor2;
-							data.gestureID = 2;
-							data.active = 1;
-							data.exists = 1;
-							data.capturable = 0;
-							data.icon = 0;
-							
-							strcpy(data.pilotFileName, MPlayer->mechData[i][j].pilotFile);
-							strcpy(data.brainFileName, "pbrain");
-							strcpy(data.csvFileName, MPlayer->mechData[i][j].mechFile);
-							data.numComponents = MPlayer->mechData[i][j].numComponents;
-							for (long k = 0; k < MPlayer->mechData[i][j].numComponents; k++)
-								data.components[k] = MPlayer->mechData[i][j].components[k];
-							long moverHandle = mission->addMover(&data);
-							if (moverHandle < 1)
-								STOP(("Logistics.beginMission: unable to addMover"));
-							MoverPtr mover = (MoverPtr)ObjectManager->get(moverHandle);
-							if (!mover)
-								STOP(("Logistics.beginMission: NULL mover"));
-							if (mover->getObjectClass() != BATTLEMECH)
-								STOP(("Logistics.beginMission: not a mech"));
-							((BattleMech*)mover)->cBills = MPlayer->mechData[i][j].cBills;
-							strcpy(((BattleMech*)mover)->variantName, MPlayer->mechData[i][j].variantName);
-							data.variant = MPlayer->mechData[i][j].variantNum;
-						}
-					}
-				}
-			}
-		}
-		else // gotta update pilot availability
-		{
-			long count = 256;
-			LogisticsPilot* pilots[256];
-			LogisticsData::instance->getPilots( pilots, count );
+            for (int i = 0; i < count; i++)
+            {
+                pilots[i]->setUsed(0);
+            }
 
-			for ( int i = 0; i < count; i++ )
-			{
-				pilots[i]->setUsed(0);
-			}
+            Team* pTeam = Team::home;
 
-			Team* pTeam = Team::home;
+            if (pTeam)
+            {
+                for (int i = pTeam->getRosterSize() - 1; i > -1; i--)
+                {
+                    Mover* pMover = (Mover*)pTeam->getMover(i);
+                    if (pMover && pMover->getCommander()->getId() == Commander::home->getId())
+                    {
+                        LogisticsPilot* pPilot = LogisticsData::instance->getPilot(pMover->getPilot()->getName());
+                        if (pPilot)
+                            pPilot->setUsed(true);
+                    }
+                }
+            }
+        }
+        
+        CompressedMech mechData;
+        mechData.commanderID = MPlayer->commanderID;
+        MPlayer->sendMissionSetup(0, 2, &mechData);
+        if (!MPlayer->waitTillMissionLoaded()) {
+            // SERVER DROPPED
+            mission->destroy();
+            return(0);
+        }
+    }
+    else if (missionLoadType == MISSION_LOAD_SP_LOGISTICS) {
+        EList<LogisticsMech*, LogisticsMech*> list;
+        LogisticsData::instance->getForceGroup(list);
 
-			if ( pTeam )
-			{
-				for (int i = pTeam->getRosterSize() - 1; i > -1; i-- )
-				{
-					Mover* pMover = (Mover*)pTeam->getMover( i );
-					if ( pMover && pMover->getCommander()->getId() == Commander::home->getId() )
-					{
-						LogisticsPilot* pPilot = LogisticsData::instance->getPilot( pMover->getPilot()->getName() );
-						if ( pPilot )
-							pPilot->setUsed( true );
-					}
-				}
-			}
-					
+        float rotation = list.Count() ? 360.f / list.Count() : 0.f;
 
-		}
-		
-		CompressedMech mechData;
-		mechData.commanderID = MPlayer->commanderID;
-		MPlayer->sendMissionSetup(0, 2, &mechData);
-		if (!MPlayer->waitTillMissionLoaded()) {
-			// SERVER DROPPED
-			mission->destroy();
-			return(0);
-		}
+        MoverInitData data;
+        memset(&data, 0, sizeof(data));
+        data.rosterIndex = 255;
+        data.controlType = 2;
+        data.controlDataType = 1;
+        data.position.Zero(); // need to get the drop zone location
+        data.rotation = 0;
+        data.teamID = Team::home->getId();
+        data.commanderID = Team::home->getId();
+        data.active = 1;
+        data.exists = 1;
+        data.capturable = 0;
+        data.baseColor = prefs.baseColor;
+        data.highlightColor1 = prefs.highlightColor;
+        data.highlightColor2 = prefs.highlightColor;
+        
+        strcpy(data.pilotFileName, "pmw00031");
+        strcpy(data.brainFileName, "pbrain");
+    
+        Stuff::Vector3D vector;
+        vector.x = 0.f;
+        vector.y = 1.f;
+        vector.z = 0.f;
+        Stuff::Vector3D scaled;
+        for (EList<LogisticsMech*, LogisticsMech*>::EIterator iter = list.Begin(); !iter.IsDone(); iter++) {
+            scaled = vector;
+            scaled *= 128.;
+            data.position.Add(dropZoneList[0], scaled);
+            //data.position = dropZoneList[dropZoneIndex++];
+            data.objNumber = (*iter)->getFitID();
+            strcpy(data.csvFileName, (*iter)->getFileName());
+            if (!(*iter)->getPilot())
+                continue;
+            strcpy(data.pilotFileName, (*iter)->getPilot()->getFileName());
+            data.overrideLoadedPilot = true;
+            data.gunnerySkill = (*iter)->getPilot()->getGunnery();
+            data.pilotingSkill = (*iter)->getPilot()->getPiloting();
 
-		}
-	else if (missionLoadType == MISSION_LOAD_SP_LOGISTICS) {
-		EList< LogisticsMech*, LogisticsMech* > list;
-		LogisticsData::instance->getForceGroup( list );
+            memcpy(data.specialtySkills, (*iter)->getPilot()->getSpecialtySkills(), sizeof(bool) * NUM_SPECIALTY_SKILLS);
+            if (!(*iter)->getVariant()->isDesignerMech())
+            {		
+                data.variant = 0;
+                mission->addMover(&data, (*iter));
+            }
+            else
+            {
+                data.variant = (*iter)->getVariant()->getFileID();
+                mission->addMover(&data);
+            }
+            Rotate(vector, rotation);
+        }
+    }
 
-		float rotation = list.Count() ? 360.f/list.Count() : 0.f;
+    mission->missionInterface->initMechs();
 
-		MoverInitData data;
-		memset( &data, 0, sizeof( data ) );
-		data.rosterIndex = 255;
-		data.controlType = 2;
-		data.controlDataType = 1;
-		data.position.Zero(); // need to get the drop zone location
-		data.rotation = 0;
-		data.teamID = Team::home->getId();
-		data.commanderID = Team::home->getId();
-		data.active = 1;
-		data.exists = 1;
-		data.capturable = 0;
-		data.baseColor = prefs.baseColor;
-		data.highlightColor1 = prefs.highlightColor;
-		data.highlightColor2 = prefs.highlightColor;
-		
+    eye->activate();
+    eye->update();
+    mission->start();
+    mission->update(); // force this, so we don't render first
 
-		strcpy( data.pilotFileName, "pmw00031" );
-		strcpy( data.brainFileName, "pbrain" );
-	
-		Stuff::Vector3D vector;
-		vector.x = 0.f;
-		vector.y = 1.f;
-		vector.z = 0.f;
-		Stuff::Vector3D scaled;
-		for ( EList< LogisticsMech*, LogisticsMech* >::EIterator iter = list.Begin(); !iter.IsDone(); iter++) {
-			scaled = vector;
-			scaled *= 128.;
-			data.position.Add(dropZoneList[0], scaled);
-			//data.position = dropZoneList[dropZoneIndex++];
-			data.objNumber = (*iter)->getFitID();
-			strcpy( data.csvFileName, (*iter)->getFileName() );
-			if ( !(*iter)->getPilot() )
-				continue;
-			strcpy( data.pilotFileName, (*iter)->getPilot()->getFileName() );
-			data.overrideLoadedPilot = true;
-			data.gunnerySkill = (*iter)->getPilot()->getGunnery();
-			data.pilotingSkill = (*iter)->getPilot()->getPiloting();
+    if (MPlayer) {
+        CompressedMech mechData;
+        mechData.commanderID = MPlayer->commanderID;
+        MPlayer->sendMissionSetup(0, 4, &mechData);
+        if (!MPlayer->waitTillMissionSetup()) {
+            // SERVER DROPPED
+            mission->destroy();
+            return(0);
+        }
+        MPlayer->setMode(MULTIPLAYER_MODE_MISSION);
+    }
 
-			memcpy(data.specialtySkills,(*iter)->getPilot()->getSpecialtySkills(),sizeof(bool) * NUM_SPECIALTY_SKILLS);
-			if ( !(*iter)->getVariant()->isDesignerMech())
-			{		
-				data.variant = 0;
-				mission->addMover( &data, (*iter));
-			}
-			else
-			{
-				data.variant = (*iter)->getVariant()->getFileID();
-				mission->addMover( &data );
-			}
-			Rotate( vector, rotation );
-		}
-	}
+    if (MPlayer && MPlayer->hostLeft) {
+        mission->destroy();
+        return(0);
+    }
 
-/*	if (MPlayer) {
-		if (MPlayer->isHost())
-			MPlayer->serverCID = MPlayer->commanderID;
-		else {
-			for (long i = 0; i < MAX_MC_PLAYERS; i++)
-				if (MPlayer->serverPlayer && (MPlayer->playerList[i].player == MPlayer->serverPlayer))
-					MPlayer->serverCID = MPlayer->playerList[i].commanderID;
-			if (MPlayer->serverCID == -1)
-				STOP(("Logistics.beginMission: bad serverCID"));
-		}
-	}
-*/
-	mission->missionInterface->initMechs();
-
-	eye->activate();
-	eye->update();
-	mission->start();
-	mission->update(); // force this, so we don't render first
-
-	if (MPlayer) {
-		CompressedMech mechData;
-		mechData.commanderID = MPlayer->commanderID;
-		MPlayer->sendMissionSetup(0, 4, &mechData);
-		if (!MPlayer->waitTillMissionSetup()) {
-			// SERVER DROPPED
-				mission->destroy();
-				return(0);
-		}
-		MPlayer->setMode(MULTIPLAYER_MODE_MISSION);
-	}
-
-	if (MPlayer && MPlayer->hostLeft) {
-		mission->destroy();
-		return(0);
-	}
-
-	return(1);
+    return(1);
 }
 
 int Logistics::DoBeginMission()
 {
-
 #ifndef TEST_SHELL
 //---------------------------
 // Networking startup code...
 #if 0
-	/*MPlayer->launchedFromLobby =*/ gos_NetCheckLobby();
-	Environment.NetworkGame = TRUE;
-	if (!MPlayer->launchedFromLobby) {
-		if (!gos_NetStartGame(0)) {
-			//gos_TerminateApplication();
-			return;
-		}
-	}
+    /*MPlayer->launchedFromLobby =*/ gos_NetCheckLobby();
+    Environment.NetworkGame = TRUE;
+    if (!MPlayer->launchedFromLobby) {
+        if (!gos_NetStartGame(0)) {
+            //gos_TerminateApplication();
+            return;
+        }
+    }
 #endif				
 
-if (!MPlayer) {
-	logistics->setLogisticsState(log_DONE);
-	soundSystem->playBettySample(BETTY_NEW_CAMPAIGN);
-}
-
+    if (!MPlayer) {
+        logistics->setLogisticsState(log_DONE);
+        soundSystem->playBettySample(BETTY_NEW_CAMPAIGN);
+    }
 #endif	//TEST_SHELL
 
-	return 0;
-
+    return 0;
 }
 
 void Logistics::initializeLogData()
 {
-	LogisticsData::instance->removeMechsInForceGroup();
+    LogisticsData::instance->removeMechsInForceGroup();
 
-	LogisticsData::instance->init();
-	Team* pTeam = Team::home;
+    LogisticsData::instance->init();
+    Team* pTeam = Team::home;
 
-	if ( pTeam )
-	{
-		for ( int i = pTeam->getRosterSize() - 1; i > -1; i-- )
-		{
-			Mover* pMover = (Mover*)pTeam->getMover( i );
-			LogisticsPilot* pPilot = LogisticsData::instance->getPilot(pMover->getPilot()->getName());
+    if (pTeam)
+    {
+        for (int i = pTeam->getRosterSize() - 1; i > -1; i--)
+        {
+            Mover* pMover = (Mover*)pTeam->getMover(i);
+            LogisticsPilot* pPilot = LogisticsData::instance->getPilot(pMover->getPilot()->getName());
 
-			DWORD base, highlight1, highlight2;
-			((Mech3DAppearance*)pMover->getAppearance())->getPaintScheme( highlight1, 
-				highlight2, base );
-			
-			
-			if ( pMover->getObjectType()->getObjectTypeClass() == BATTLEMECH_TYPE )
-			{
-				LogisticsVariant* pVar = LogisticsData::instance->getVariant( ((BattleMech*)pMover)->variantName );
-				LogisticsData::instance->addMechToInventory( 
-					pVar, 1, pPilot,
-					base, highlight1, highlight2 );
-			}
-		}
-	}
+            DWORD base, highlight1, highlight2;
+            ((Mech3DAppearance*)pMover->getAppearance())->getPaintScheme(highlight1, 
+                highlight2, base);
+            
+            if (pMover->getObjectType()->getObjectTypeClass() == BATTLEMECH_TYPE)
+            {
+                LogisticsVariant* pVar = LogisticsData::instance->getVariant(((BattleMech*)pMover)->variantName);
+                LogisticsData::instance->addMechToInventory(pVar, 1, pPilot, base, highlight1, highlight2);
+            }
+        }
+    }
 }
 
-void Logistics::playFullScreenVideo( const char* fileName )
+void Logistics::playFullScreenVideo(const char* fileName)
 {
-	if ( !fileName || !fileName[0])
-		return;
+    if (!fileName || !fileName[0])
+        return;
 
-	FullPathFileName path;
-	path.init( moviePath, fileName, ".bik" );
+    FullPathFileName movieName;
+    //movieName.init(moviePath, fileName, ".bik");
+    movieName.init(moviePath, fileName, ".mp4");
 
-	RECT movieRect;
-	movieRect.top = 100;
-	movieRect.left = 0;
-	movieRect.right = Environment.screenWidth;
-	movieRect.bottom = 500;
+    RECT movieRect;
+    movieRect.top = 100;
+    movieRect.left = 0;
+    movieRect.right = Environment.screenWidth;
+    movieRect.bottom = 500;
 
-	bMovie = new MC2Movie;
-	bMovie->init(path,movieRect,true);
+    SDL_Window* gameWindow = SDL_GL_GetCurrentWindow();
+    SDL_GLContext gameContext = SDL_GL_GetCurrentContext();
+    bMovie = new MP4Player(std::string(movieName), gameWindow, gameContext);
+    // Note: Using Windows RECT breaks cross-platform compatibility for now.
+    RECT convertedRect = {movieRect.left, movieRect.top, movieRect.right, movieRect.bottom};
+    bMovie->init((const char*)movieName, convertedRect, true, gameWindow, gameContext);
 
-	soundSystem->stopDigitalMusic();
+    soundSystem->stopDigitalMusic();
 }
 
-void Logistics::setResultsHostLeftDlg( const char* pName )
+void Logistics::setResultsHostLeftDlg(const char* pName)
 {
-	if ( missionResults && logisticsState == log_RESULTS )
-	{
-		missionResults->setHostLeftDlg( pName );
-	}
+    if (missionResults && logisticsState == log_RESULTS)
+    {
+        missionResults->setHostLeftDlg(pName);
+    }
 }
 //----------------------------------------------------------------------------------

--- a/code/logistics.h
+++ b/code/logistics.h
@@ -16,7 +16,7 @@
 #endif
 
 #ifndef MC2movie_H
-#include"mc2movie.h"
+#include"mp4player.h"
 #endif
 
 #include"logisticsdata.h"
@@ -101,7 +101,7 @@ class Logistics
 		int DoBeginMission();
 		void playFullScreenVideo( const char* fileName );
 
-		MC2MoviePtr	bMovie;
+		MP4Player*	bMovie;
 
 
 	private:

--- a/code/mainmenu.cpp
+++ b/code/mainmenu.cpp
@@ -1,855 +1,873 @@
 #define MAINMENU_CPP
-/*************************************************************************************************\
-MainMenu.cpp			: Implementation of the MainMenu component.
-//---------------------------------------------------------------------------//
-// Copyright (C) Microsoft Corporation. All rights reserved.                 //
-//===========================================================================//
-\*************************************************************************************************/
 
 #ifdef LINUX_BUILD
 #include "platform_windows.h"
-struct DDSURFACEDESC2 {
-};
+struct DDSURFACEDESC2 {};
 #else
-#include<windows.h>
-#include<ddraw.h>
+#include <windows.h>
+#include <ddraw.h>
 #endif
-#include"mainmenu.h"
-#include"mclib.h"
-#include"inifile.h"
-#include"logisticsdata.h"
-#include"logisticsdialog.h"
-#include"abutton.h"
-#include"optionsscreenwrapper.h"
+#include "mainmenu.h"
+#include "mclib.h"
+#include "inifile.h"
+#include <filesystem>
+#include <vector>
+#include "logisticsdata.h"
+#include "logisticsdialog.h"
+#include "abutton.h"
+#include "optionsscreenwrapper.h"
 #include "../resource.h"
-#include"mechlopedia.h"
-#include"gamesound.h"
-#include"aanimobject.h"
-#include"multplyr.h"
+#include "mechlopedia.h"
+#include "gamesound.h"
+#include "aanimobject.h"
+#include "multplyr.h"
+#include <algorithm>
+#include <mp4player.h>
+#include <iostream>
 
-#include"prefs.h"
+#include "prefs.h"
 extern CPrefs prefs;
 
-
 #define MM_MSG_NEW_CAMPAIGN 90
-#define MM_MSG_SAVE			92
-#define MM_MSG_LOAD			91
-#define MM_MSG_MULTIPLAYER	93
+#define MM_MSG_SAVE 92
+#define MM_MSG_LOAD 91
+#define MM_MSG_MULTIPLAYER 93
 #define MM_MSG_RETURN_TO_GAME 94
-#define MM_MSG_OPTIONS		95
-#define MM_MSG_ENCYCLOPEDIA	96
-#define MM_MSG_EXIT			97
-#define MM_MSG_SINGLE_MISSION	98
-#define MM_MSG_LEGAL		99
+#define MM_MSG_OPTIONS 95
+#define MM_MSG_ENCYCLOPEDIA 96
+#define MM_MSG_EXIT 97
+#define MM_MSG_SINGLE_MISSION 98
+#define MM_MSG_LEGAL 99
 
 extern volatile bool mc2IsInMouseTimer;
 extern volatile bool mc2IsInDisplayBackBuffer;
 
 void MouseTimerKill();
-
-extern void (*AsynFunc)(RECT& WinRect,DDSURFACEDESC2& mouseSurfaceDesc );
-
-
-
-
+extern void (*AsynFunc)(RECT& WinRect, DDSURFACEDESC2& mouseSurfaceDesc);
 extern bool bInvokeOptionsScreenFlag;
-bool	MainMenu::bDrawMechlopedia = false;;
+bool MainMenu::bDrawMechlopedia = false;
 
 void SplashIntro::init()
 {
-	FullPathFileName path;
-	path.init( artPath, "mcl_splashscreenintro", ".fit" );
+    FullPathFileName path;
+    path.init(artPath, "mcl_splashscreenintro", ".fit");
 
-	FitIniFile file;
-	if ( NO_ERR != file.open( path ) )
-	{
-		char errorStr[256];
-		sprintf( errorStr, "couldn't open file %s", (const char*)path );
-		Assert(0,0,errorStr );
-	}
+    FitIniFile file;
+    if (NO_ERR != file.open(path))
+    {
+        char errorStr[256];
+        sprintf(errorStr, "couldn't open file %s", (const char*)path);
+        Assert(0, 0, errorStr);
+    }
 
-	LogisticsScreen::init( file, "Static", "Text", "Rect", "Button" );
+    LogisticsScreen::init(file, "Static", "Text", "Rect", "Button");
 }
 
-MainMenu::MainMenu(  )
+MainMenu::MainMenu()
 {
-	optionsScreenWrapper = NULL;
-	bOptions = 0;
-	bSave = bLoad = 0;
-	helpTextArrayID = 0;
-	mechlopedia = 0;
-	bDrawMechlopedia = 0;
-	tuneId = -1;
-	bLoadSingle = 0; 
-	bLoadCampaign = 0;
-	introOver = 0;
-	bHostLeftDlg = 0;
-
-	introMovie = 0;
+    optionsScreenWrapper = NULL;
+    bOptions = 0;
+    bSave = bLoad = 0;
+    helpTextArrayID = 0;
+    mechlopedia = 0;
+    bDrawMechlopedia = 0;
+    tuneId = -1;
+    bLoadSingle = 0;
+    bLoadCampaign = 0;
+    introOver = 0;
+    bHostLeftDlg = 0;
+    videoFinished = false;
+    currentVideoIndex = 0; // Start with first video
+    introMP4Player = 0;
 }
-
-//-------------------------------------------------------------------------------------------------
 
 MainMenu::~MainMenu()
 {
-	if ( optionsScreenWrapper )
-		delete optionsScreenWrapper;
+    if (optionsScreenWrapper)
+        delete optionsScreenWrapper;
+    if (introMP4Player)
+        delete introMP4Player;
 }
 
-int MainMenu::init( FitIniFile& file )
+int MainMenu::init(FitIniFile& file)
 {
-	file.seekBlock("Tunes");
-	file.readIdLong("TuneId",tuneId);
+    file.seekBlock("Tunes");
+    file.readIdLong("TuneId", tuneId);
 
-	LogisticsScreen::init( file, "Static", "Text", "Rect", "Button" );
+    LogisticsScreen::init(file, "Static", "Text", "Rect", "Button");
 
-	FullPathFileName name;
-	name.init( artPath, "mcl_sp", ".fit" );
-	FitIniFile file2;
-	if ( NO_ERR != file2.open( name ) )
-	{
-		char errorStr[256];
-		sprintf( errorStr, "couldn't open file %s", (const char*)name );
-		Assert(0,0,errorStr );
-	}
+    FullPathFileName name;
+    name.init(artPath, "mcl_sp", ".fit");
+    FitIniFile file2;
+    if (NO_ERR != file2.open(name))
+    {
+        char errorStr[256];
+        sprintf(errorStr, "couldn't open file %s", (const char*)name);
+        Assert(0, 0, errorStr);
+    }
 
-	background.init( file2, "Static", "Text", "Rect", "Button" );
+    background.init(file2, "Static", "Text", "Rect", "Button");
 
-	for ( int i = 0; i < buttonCount; i++ )
-	{
-		buttons[i].setMessageOnRelease();
-		buttons[i].setPressFX(LOG_VIDEOBUTTONS);
-		buttons[i].setHighlightFX(LOG_DIGITALHIGHLIGHT);
-	}
+    for (int i = 0; i < buttonCount; i++)
+    {
+        buttons[i].setMessageOnRelease();
+        buttons[i].setPressFX(LOG_VIDEOBUTTONS);
+        buttons[i].setHighlightFX(LOG_DIGITALHIGHLIGHT);
+    }
 
-	beginAnim.initWithBlockName( &file, "InAnim" );
-	endAnim.initWithBlockName( &file, "OutAnim" );
+    beginAnim.initWithBlockName(&file, "InAnim");
+    endAnim.initWithBlockName(&file, "OutAnim");
 
+    intro.init();
 
-	intro.init();
+    FullPathFileName path;
+    path.init(artPath, "mcl_mp_loadmap", ".fit");
 
-	FullPathFileName path;
-	path.init( artPath, "mcl_mp_loadmap", ".fit" );
+    FitIniFile mpFile;
+    if (NO_ERR != mpFile.open(path))
+    {
+        char error[256];
+        sprintf(error, "couldn't open file %s", (const char*)path);
+        Assert(0, 0, error);
+        return -1;
+    }
 
-	FitIniFile mpFile;
+    singleLoadDlg.init(&mpFile);
 
-	if ( NO_ERR != mpFile.open( path ) )
-	{
-		char error[256];
-		sprintf( error, "couldn't open file %s", (const char*)path );
-		Assert( 0, 0, error );
-		return -1;		
-	}
+    SDL_Window* gameWindow = SDL_GL_GetCurrentWindow();
+    SDL_GLContext gameContext = SDL_GL_GetCurrentContext();
 
-	singleLoadDlg.init( &mpFile );
+    SDL_SetWindowFullscreen(gameWindow, SDL_WINDOW_FULLSCREEN_DESKTOP);
+    int windowWidth, windowHeight;
+    SDL_GetWindowSize(gameWindow, &windowWidth, &windowHeight);
+    std::cout << "[MainMenu] Forced fullscreen, window size: " << windowWidth << "x" << windowHeight << "\n";
 
-	introMovie = 0;
-
-	path.init( moviePath, "msft", ".bik" );
-
-	RECT movieRect;
-	movieRect.top = 0;
-	movieRect.left = 0;
-	movieRect.right = Environment.screenWidth;
-	movieRect.bottom = Environment.screenHeight;
-
-	introMovie = new MC2Movie;
-	introMovie->init(path,movieRect,true);
-
-	return 0;
+    return 0;
 }
 
 void MainMenu::begin()
 {
-	status = RUNNING;
-	promptToQuit = 0;
-	beginAnim.begin();
-	beginFadeIn( 0 );
-	endAnim.end();
-	background.beginFadeIn( 0 );
-	endResult = RUNNING;
-	musicStarted = false;
-	bLoadSingle = 0;
-	bLoadCampaign = 0;
-	promptToDisconnect = 0; 
-	bLegal = 0;
+    status = RUNNING;
+    promptToQuit = 0;
+    beginAnim.begin();
+    beginFadeIn(0);
+    endAnim.end();
+    background.beginFadeIn(0);
+    endResult = RUNNING;
+    musicStarted = false;
+    bLoadSingle = 0;
+    bLoadCampaign = 0;
+    promptToDisconnect = 0;
+    bLegal = 0;
 
-	// no host left dlg, sometimes we get this begin call 2x's due to netlib weirdness
-	if ( !introMovie )
-	{
-			while (mc2IsInMouseTimer)
-				;
+    // Start video sequence if not finished
+    if (!videoFinished) {
+        std::vector<std::string> introVideos = {"MSFT.mp4", "CINEMA1.mp4"};
+        
+        if (currentVideoIndex < introVideos.size()) {
+            // Clean up any existing player first
+            if (introMP4Player) {
+                delete introMP4Player;
+                introMP4Player = nullptr;
+            }
+            
+            std::string currentVideo = introVideos[currentVideoIndex];
+            std::string mp4Path = std::string(moviePath) + currentVideo;
+            
+            std::cout << "[MainMenu] Starting intro video " << (currentVideoIndex + 1) 
+                      << "/" << introVideos.size() << ": " << currentVideo << "\n";
+            
+            SDL_Window* gameWindow = SDL_GL_GetCurrentWindow();
+            SDL_GLContext gameContext = SDL_GL_GetCurrentContext();
+            
+            if (gameWindow && gameContext) {
+                // Create MP4Player for proper video handling
+                introMP4Player = new MP4Player(mp4Path, gameWindow, gameContext);
+                
+                // Initialize with fullscreen rectangle and no looping
+                RECT movieRect = {0, 0, Environment.screenWidth, Environment.screenHeight};
+                introMP4Player->init(mp4Path.c_str(), movieRect, false, gameWindow, gameContext);
+                
+                // Start playback
+                introMP4Player->restart();
+                
+                std::cout << "[MainMenu] Video initialized and started\n";
+            } else {
+                std::cout << "[MainMenu] ERROR: No valid window/context for video\n";
+                videoFinished = true;
+            }
+        } else {
+            videoFinished = true;
+        }
+    }
 
-			//ONLY set the mouse BLT data at the end of each update.  NO MORE FLICKERING THEN!!!
-			// BLOCK THREAD WHILE THIS IS HAPPENING
-			mc2IsInDisplayBackBuffer = true;
+    // If videos are done, proceed with normal menu setup
+    if (videoFinished) {
+        while (mc2IsInMouseTimer);
+        mc2IsInDisplayBackBuffer = true;
+        mc2UseAsyncMouse = prefs.asyncMouse;
+        if (!mc2UseAsyncMouse)
+            MouseTimerKill();
+        mc2IsInDisplayBackBuffer = false;
 
-			mc2UseAsyncMouse = prefs.asyncMouse;
-			if ( !mc2UseAsyncMouse)
-				MouseTimerKill();
+        AsynFunc = NULL;
+        userInput->initMouseCursors("cursors");
+        userInput->mouseOn();
+        userInput->setMouseCursor(mState_LOGISTICS);
 
-			mc2IsInDisplayBackBuffer = false;
+        DWORD localRenderer = prefs.renderer;
+        if (prefs.renderer != 0 && prefs.renderer != 3)
+            localRenderer = 0;
 
-			AsynFunc = NULL;
+        bool localFullScreen = prefs.fullScreen;
+        if (Environment.fullScreen && prefs.fullScreen)
+            localFullScreen = false;
 
-			//Force mouse Cursors to smaller or larger depending on new video mode.
-			userInput->initMouseCursors("cursors");
-			userInput->mouseOn();
-			userInput->setMouseCursor( mState_LOGISTICS );
-
-			DWORD localRenderer = prefs.renderer;
-			if (prefs.renderer != 0 && prefs.renderer != 3)
-				localRenderer = 0;
-
-   			bool localFullScreen = prefs.fullScreen;
-   			bool localWindow = !prefs.fullScreen;
-   			if (Environment.fullScreen && prefs.fullScreen)
-   				localFullScreen = false;
-
-
-			// make sure we get into 800 x 600 mode
-			if ( Environment.screenWidth != 800 )
-			{
-			
-				if (prefs.renderer == 3)
-					gos_SetScreenMode(800,600,16,0,0,0,true,localFullScreen,0,localWindow,0,localRenderer);
-				else
-					gos_SetScreenMode(800,600,16,prefs.renderer,0,0,0,localFullScreen ,0,localWindow,0,localRenderer);
-			}
-
-
-	}
+        if (Environment.screenWidth != 800) {
+            if (prefs.renderer == 3)
+                gos_SetScreenMode(800, 600, 16, 0, 0, localFullScreen, true, false, false);
+            else
+                gos_SetScreenMode(800, 600, 16, localRenderer, 0, localFullScreen, false, false, false);
+        }
+    }
 }
 
 void MainMenu::end()
 {
-	endAnim.end();
-	bHostLeftDlg = 0;
-
+    endAnim.end();
+    bHostLeftDlg = 0;
 }
 
-void MainMenu::setDrawBackground( bool bNewDrawBackground )
+void MainMenu::setDrawBackground(bool bNewDrawBackground)
 {
-	bDrawBackground = bNewDrawBackground;
-	if ( bDrawBackground && !introOver)
-	{
-		intro.begin();
-	}
+    bDrawBackground = bNewDrawBackground;
+    if (bDrawBackground && !introOver)
+    {
+        intro.begin();
+    }
 }
 
-int	MainMenu::handleMessage( unsigned long what, unsigned long who )
+int MainMenu::handleMessage(unsigned long what, unsigned long who)
 {
-	switch ( who )
-	{
-		case MM_MSG_NEW_CAMPAIGN:
-			if ( MPlayer )
-			{
-				LogisticsOKDialog::instance()->setText( IDS_PROMPT_TO_DISCONNECT, IDS_DIALOG_NO, IDS_DIALOG_YES );
-				LogisticsOKDialog::instance()->begin();
-				endResult = MM_MSG_NEW_CAMPAIGN;
-				promptToDisconnect = true;
-			}
-			else
-			{
-				endAnim.begin();
-				beginAnim.end();
-				bLoadCampaign = true;
-				LogisticsSaveDialog::instance()->beginCampaign();
-				if ( LogisticsSaveDialog::instance()->isDone() )
-				{
-					LogisticsData::instance->startNewCampaign( LogisticsSaveDialog::instance()->getFileName());
-					status = RESTART;
-				}
-			}
-			break;
-		case MM_MSG_SAVE:
-			if ( MPlayer )
-			{
-				LogisticsOKDialog::instance()->setText( IDS_PROMPT_TO_DISCONNECT, IDS_DIALOG_NO, IDS_DIALOG_YES );
-				LogisticsOKDialog::instance()->begin();
-				endResult = who;
-				promptToDisconnect = true;
-			}
-			else
-			{
-		
-				// need to pop dialog here
-				LogisticsSaveDialog::instance()->begin();
-				endAnim.begin();
-				beginAnim.end();
-				bSave = true;
-			}
-			break;
+    switch (who)
+    {
+    case MM_MSG_NEW_CAMPAIGN:
+        if (MPlayer)
+        {
+            LogisticsOKDialog::instance()->setText(IDS_PROMPT_TO_DISCONNECT, IDS_DIALOG_NO, IDS_DIALOG_YES);
+            LogisticsOKDialog::instance()->begin();
+            endResult = MM_MSG_NEW_CAMPAIGN;
+            promptToDisconnect = true;
+        }
+        else
+        {
+            endAnim.begin();
+            beginAnim.end();
+            bLoadCampaign = true;
+            LogisticsSaveDialog::instance()->beginCampaign();
+            if (LogisticsSaveDialog::instance()->isDone())
+            {
+                LogisticsData::instance->startNewCampaign(LogisticsSaveDialog::instance()->getFileName());
+                status = RESTART;
+            }
+        }
+        break;
+    case MM_MSG_SAVE:
+        if (MPlayer)
+        {
+            LogisticsOKDialog::instance()->setText(IDS_PROMPT_TO_DISCONNECT, IDS_DIALOG_NO, IDS_DIALOG_YES);
+            LogisticsOKDialog::instance()->begin();
+            endResult = who;
+            promptToDisconnect = true;
+        }
+        else
+        {
+            LogisticsSaveDialog::instance()->begin();
+            endAnim.begin();
+            beginAnim.end();
+            bSave = true;
+        }
+        break;
 
-		case MM_MSG_LOAD:
+    case MM_MSG_LOAD:
+        if (MPlayer)
+        {
+            LogisticsOKDialog::instance()->setText(IDS_PROMPT_TO_DISCONNECT, IDS_DIALOG_NO, IDS_DIALOG_YES);
+            LogisticsOKDialog::instance()->begin();
+            endResult = who;
+            promptToDisconnect = true;
+        }
+        else
+        {
+            LogisticsSaveDialog::instance()->beginLoad();
+            endAnim.begin();
+            beginAnim.end();
+            bLoad = true;
+        }
+        break;
+    case MM_MSG_MULTIPLAYER:
+        if (MPlayer)
+        {
+            LogisticsOKDialog::instance()->setText(IDS_PROMPT_TO_DISCONNECT, IDS_DIALOG_NO, IDS_DIALOG_YES);
+            LogisticsOKDialog::instance()->begin();
+            endResult = who;
+            promptToDisconnect = true;
+        }
+        else
+        {
+            endAnim.begin();
+            beginAnim.end();
+            endResult = MULTIPLAYERRESTART;
+            LogisticsData::instance->startMultiPlayer();
+        }
+        break;
 
-			if ( MPlayer )
-			{
-				LogisticsOKDialog::instance()->setText( IDS_PROMPT_TO_DISCONNECT, IDS_DIALOG_NO, IDS_DIALOG_YES );
-				LogisticsOKDialog::instance()->begin();
-				endResult = who;
-				promptToDisconnect = true;
-			}
-			else
-			{
-			
-				// need to pop dialog here
-				LogisticsSaveDialog::instance()->beginLoad();
-				endAnim.begin();
-				beginAnim.end();
-				bLoad = true;
-			}
-			break;
-		case MM_MSG_MULTIPLAYER:
-			if ( MPlayer )
-			{
-				LogisticsOKDialog::instance()->setText( IDS_PROMPT_TO_DISCONNECT, IDS_DIALOG_NO, IDS_DIALOG_YES );
-				LogisticsOKDialog::instance()->begin();
-				endResult = who;
-				promptToDisconnect = true;
-			}
-			else
-			{
-				endAnim.begin();
-				beginAnim.end();
-				endResult = MULTIPLAYERRESTART;
-				LogisticsData::instance->startMultiPlayer();
-			}
-			break;
+    case MM_MSG_RETURN_TO_GAME:
+        if (!bDrawBackground)
+        {
+            endAnim.begin();
+            beginAnim.end();
+            endResult = NEXT;
+            soundSystem->playDigitalSample(LOG_MAINMENUBUTTON);
+            soundSystem->playDigitalMusic(LogisticsData::instance->getCurrentMissionTune());
+        }
+        break;
+    case MM_MSG_OPTIONS:
+        if (!optionsScreenWrapper)
+        {
+            optionsScreenWrapper = new OptionsScreenWrapper;
+            optionsScreenWrapper->init();
+        }
+        optionsScreenWrapper->begin();
+        bOptions = true;
+        break;
+    case MM_MSG_ENCYCLOPEDIA:
+        bDrawMechlopedia = true;
+        beginFadeOut(1.0);
+        if (!mechlopedia)
+        {
+            mechlopedia = new Mechlopedia;
+            mechlopedia->init();
+        }
+        mechlopedia->begin();
+        break;
+    case MM_MSG_EXIT:
+        promptToQuit = 1;
+        LogisticsOKDialog::instance()->setText(IDS_DIALOG_QUIT_PROMPT, IDS_DIALOG_NO, IDS_DIALOG_YES);
+        LogisticsOKDialog::instance()->begin();
+        getButton(who)->press(0);
+        break;
 
-		case MM_MSG_RETURN_TO_GAME:
-			{
-			if ( !bDrawBackground )
-			{
-				endAnim.begin();
-				beginAnim.end();
-				endResult = NEXT;
-				soundSystem->playDigitalSample( LOG_MAINMENUBUTTON );
-				soundSystem->playDigitalMusic(LogisticsData::instance->getCurrentMissionTune());
-			}
-			}
-			break;
-		case MM_MSG_OPTIONS:
-			// need to throw up the options screen here...
-			if (!optionsScreenWrapper)
-			{
-				optionsScreenWrapper = new OptionsScreenWrapper;
-				optionsScreenWrapper->init();
-			}
-			optionsScreenWrapper->begin();
+    case MM_MSG_SINGLE_MISSION:
+        if (MPlayer)
+        {
+            LogisticsOKDialog::instance()->setText(IDS_PROMPT_TO_DISCONNECT, IDS_DIALOG_NO, IDS_DIALOG_YES);
+            LogisticsOKDialog::instance()->begin();
+            endResult = who;
+            promptToDisconnect = true;
+        }
+        else
+        {
+            bLoadSingle = true;
+            endAnim.begin();
+            beginAnim.end();
+            singleLoadDlg.beginSingleMission();
+            getButton(who)->press(0);
+        }
+        break;
 
-			bOptions = true;
-			break;
-		case MM_MSG_ENCYCLOPEDIA:
-			bDrawMechlopedia = true;
-			beginFadeOut(1.0);
-			if ( !mechlopedia )
-			{
-				mechlopedia = new Mechlopedia;
-				mechlopedia->init();
-			}
+    case MM_MSG_LEGAL:
+    {
+        bLegal = 1;
+        if (!LogisticsLegalDialog::instance())
+        {
+            FullPathFileName path;
+            path.init(artPath, "mcl_dialoglegal", ".fit");
+            FitIniFile file;
+            file.open(path);
+            LogisticsLegalDialog::init(file);
+        }
+        LogisticsLegalDialog::instance()->setText(IDS_DIALOG_OK, IDS_DIALOG_OK, IDS_DIALOG_OK);
+        char realText[2048];
+        cLoadString(IDS_LAWYER_BABBLE, realText, 2047);
+        char lawyerBabble[2048];
+        DWORD pIDLen = 64;
+        char pID[64];
+        sprintf(pID, "INVALID ID");
+        gos_LoadDataFromRegistry("PID", pID, &pIDLen);
+        sprintf(lawyerBabble, realText, pID);
+        LogisticsLegalDialog::instance()->setText(lawyerBabble);
+        LogisticsLegalDialog::instance()->begin();
+        LogisticsLegalDialog::instance()->setFont(IDS_LAWYER_BABBLE_FONT);
+        getButton(who)->press(0);
+    }
+    break;
+    default:
+        break;
+    }
 
-			mechlopedia->begin();
-			break;
-		case MM_MSG_EXIT:
-			promptToQuit = 1;
-			// may need to set the text here
-			LogisticsOKDialog::instance()->setText( IDS_DIALOG_QUIT_PROMPT,
-					IDS_DIALOG_NO, IDS_DIALOG_YES );
-				
-			LogisticsOKDialog::instance()->begin();
-			getButton( who )->press( 0 );
-			break;
-
-		case MM_MSG_SINGLE_MISSION:
-
-			if ( MPlayer )
-			{
-				LogisticsOKDialog::instance()->setText( IDS_PROMPT_TO_DISCONNECT, IDS_DIALOG_NO, IDS_DIALOG_YES );
-				LogisticsOKDialog::instance()->begin();
-				endResult = who;
-				promptToDisconnect = true;
-			}
-			else
-			{
-				bLoadSingle = true;
-				endAnim.begin();
-				beginAnim.end();
-				singleLoadDlg.beginSingleMission();
-				getButton( who )->press( 0 );
-			}
-			break;
-
-		case MM_MSG_LEGAL:
-			{
-				bLegal = 1;
-				// may need to set the text here
-				if ( !LogisticsLegalDialog::instance() )
-				{
-					FullPathFileName path;
-					path.init( artPath, "mcl_dialoglegal", ".fit" );
-					FitIniFile file;
-					file.open( path );
-					LogisticsLegalDialog::init( file );
-				}
-				LogisticsLegalDialog::instance()->setText( IDS_DIALOG_OK,
-						IDS_DIALOG_OK, IDS_DIALOG_OK );
-				//Needs to be this long for LOC!
-				// -fs
-				char realText[2048];
-				cLoadString(IDS_LAWYER_BABBLE, realText, 2047 );
-				char lawyerBabble[2048];
-				DWORD pIDLen = 64;
-				char pID[64];
-				sprintf( pID, "INVALID ID" );
-				gos_LoadDataFromRegistry("PID", pID, &pIDLen);
-				sprintf( lawyerBabble, realText, pID );
-				LogisticsLegalDialog::instance()->setText( lawyerBabble );
-				LogisticsLegalDialog::instance()->begin();
-				LogisticsLegalDialog::instance()->setFont( IDS_LAWYER_BABBLE_FONT );				
-				getButton( who )->press( 0 );
-			}
-			break;
-		default:
-			break;
-	}
-
-	return 0;
+    return 0;
 }
 
 void MainMenu::skipIntro()
 {
-	if ( introMovie )
-	{
-		introMovie->stop();
-		delete introMovie;
-		introMovie = NULL;
-
-	}
+    std::cout << "[MainMenu] Skipping intro video sequence\n";
+    
+    if (introMP4Player)
+    {
+        introMP4Player->stop();
+        delete introMP4Player;
+        introMP4Player = nullptr;
+    }
+    
+    videoFinished = true;
+    currentVideoIndex = 0; // Reset for next time
+    userInput->mouseOn();
+    userInput->setMouseCursor(mState_LOGISTICS);
+    std::cout << "[MainMenu] Intro sequence skipped, returning to menu\n";
 }
 
 void MainMenu::update()
 {
+    if (bDrawBackground || MPlayer || LogisticsData::instance->isSingleMission())
+    {
+        getButton(MM_MSG_SAVE)->disable(true);
+    }
+    else
+    {
+        getButton(MM_MSG_SAVE)->disable(false);
+    }
 
-	if ( bDrawBackground || MPlayer || LogisticsData::instance->isSingleMission() )
-	{
-		getButton( MM_MSG_SAVE )->disable( true );
-	}
-	else
-		getButton( MM_MSG_SAVE )->disable( false );
+    getButton(MM_MSG_MULTIPLAYER)->disable(true);
 
-	getButton( MM_MSG_MULTIPLAYER )->disable( true );
+    // Handle intro video sequence
+    if (introMP4Player && !videoFinished)
+    {
+        // Check for skip input
+        if (userInput->getKeyDown(KEY_SPACE) || userInput->getKeyDown(KEY_ESCAPE) || userInput->getKeyDown(KEY_LMOUSE))
+        {
+            skipIntro();
+            return;
+        }
+        
+        // Update and render the video
+        introMP4Player->update();
+        introMP4Player->render();
+        
+        // Check if video has ended
+        if (!introMP4Player->isPlaying())
+        {
+            std::cout << "[MainMenu::update] Video ended naturally\n";
+            delete introMP4Player;
+            introMP4Player = nullptr;
+            
+            currentVideoIndex++;
+            
+            // Check if more videos to play
+            std::vector<std::string> introVideos = {"MSFT.mp4", "CINEMA1.mp4"};
+            if (currentVideoIndex >= introVideos.size()) {
+                std::cout << "[MainMenu::update] All intro videos completed\n";
+                videoFinished = true;
+                userInput->mouseOn();
+                userInput->setMouseCursor(mState_LOGISTICS);
+            } else {
+                std::cout << "[MainMenu::update] Starting next video in sequence\n";
+                begin(); // Start next video
+                return;
+            }
+        } else {
+            return; // Continue playing current video
+        }
+    }
+    
+    // Check if we need to continue video sequence (fallback)
+    if (!introMP4Player && !videoFinished)
+    {
+        std::vector<std::string> introVideos = {"MSFT.mp4", "CINEMA1.mp4"};
+        
+        if (currentVideoIndex < introVideos.size()) {
+            std::cout << "[MainMenu::update] Fallback - restarting video sequence\n";
+            begin();
+            return;
+        } else {
+            videoFinished = true;
+        }
+    }
 
-	if ( introMovie )
-	{
-		userInput->mouseOff();
+    if (!musicStarted)
+    {
+        musicStarted = true;
+        soundSystem->setMusicVolume(prefs.MusicVolume);
+        soundSystem->playDigitalMusic(tuneId);
+    }
 
-		if (userInput->getKeyDown(KEY_SPACE) || userInput->getKeyDown(KEY_ESCAPE) || userInput->getKeyDown(KEY_LMOUSE))
-		{
-			introMovie->stop();
-		}
+    if (endAnim.isDone())
+    {
+        status = endResult;
+    }
 
-		bool result = introMovie->update();
-		if (result)
-		{
-			
-			//Movie's Over.
-			//Whack it.
-			delete introMovie;
-			introMovie = NULL;
-		}
+    if (bDrawMechlopedia)
+    {
+        mechlopedia->update();
+        if (mechlopedia->getStatus() == NEXT)
+        {
+            beginFadeIn(0);
+            bDrawMechlopedia = 0;
+            if (!bDrawBackground)
+                status = NEXT;
+        }
+        return;
+    }
 
-		return;
-	}
+    if (bOptions)
+    {
+        OptionsScreenWrapper::status_type result = optionsScreenWrapper->update();
+        if (result == OptionsScreenWrapper::opt_DONE)
+        {
+            optionsScreenWrapper->end();
+            bOptions = 0;
+        }
+        return;
+    }
 
-	if (!musicStarted)
-	{
-		musicStarted = true;
-		soundSystem->setMusicVolume( prefs.MusicVolume );
-		soundSystem->playDigitalMusic(tuneId);
-	}
+    if ((bSave || bLoad || bLoadCampaign) && endAnim.isDone())
+    {
+        LogisticsSaveDialog::instance()->update();
 
-	if ( endAnim.isDone() )
-	{
-		status = endResult;
-	}
+        if (LogisticsSaveDialog::instance()->getStatus() == LogisticsScreen::YES && LogisticsSaveDialog::instance()->isDone())
+        {
+            char name[1024];
+            strcpy(name, savePath);
+            strcat(name, LogisticsSaveDialog::instance()->getFileName());
+            size_t index = strlen(name) - 4;
+            if (S_stricmp(&name[index], ".fit") != 0)
+                strcat(name, ".fit");
 
-	if ( bDrawMechlopedia )
-	{
-		mechlopedia->update();
-		if ( mechlopedia->getStatus() == NEXT )
-		{
-			beginFadeIn( 0 );
-			bDrawMechlopedia = 0;
-			if ( !bDrawBackground )
-				status = NEXT;
-		}
-		return;
-	}
+            FitIniFile file;
+            if (bSave)
+            {
+                CreateDirectory(savePath, NULL);
+                if (NO_ERR != file.createWithCase(name))
+                {
+                    char errorStr[1024];
+                    sprintf(errorStr, "couldn't open the file %s", name);
+                    Assert(0, 0, errorStr);
+                }
+                else
+                {
+                    LogisticsData::instance->save(file);
+                    LogisticsSaveDialog::instance()->end();
+                    file.close();
+                }
+                bSave = bLoad = 0;
+                status = NEXT;
+            }
+            else if (bLoadCampaign)
+            {
+                LogisticsData::instance->startNewCampaign(LogisticsSaveDialog::instance()->getFileName());
+                status = endResult = RESTART;
+                bLoadCampaign = 0;
+            }
+            else
+            {
+                const bool do_not_make_lower = true;
+                if (NO_ERR != file.open(name, READ, 50, do_not_make_lower))
+                {
+                    char errorStr[1024];
+                    sprintf(errorStr, "couldn't open the file %s", name);
+                    Assert(0, 0, errorStr);
+                }
+                else
+                    LogisticsData::instance->load(file);
+                LogisticsSaveDialog::instance()->end();
+                bSave = bLoad = 0;
+                status = RESTART;
+                file.close();
+            }
+        }
+        else if (LogisticsSaveDialog::instance()->getStatus() == LogisticsScreen::NO && LogisticsSaveDialog::instance()->isDone())
+        {
+            LogisticsSaveDialog::instance()->end();
+            bSave = bLoad = bLoadCampaign = 0;
+            if (!bDrawBackground)
+                status = NEXT;
+            else
+            {
+                beginAnim.begin();
+                endAnim.end();
+            }
+        }
+        return;
+    }
+    else if (bLoadSingle && endAnim.isDone())
+    {
+        singleLoadDlg.update();
+        if (singleLoadDlg.isDone())
+        {
+            if (singleLoadDlg.getStatus() == YES)
+            {
+                const char* pName = singleLoadDlg.getMapFileName();
+                if (pName)
+                {
+                    LogisticsData::instance->setSingleMission(pName);
+                    status = SKIPONENEXT;
+                }
+            }
+            bLoadSingle = 0;
+            beginAnim.begin();
+            endAnim.end();
+        }
+    }
+    else if (promptToQuit)
+    {
+        LogisticsOKDialog::instance()->update();
+        if (LogisticsOKDialog::instance()->getStatus() == LogisticsScreen::YES)
+        {
+            soundSystem->playDigitalSample(LOG_EXITGAME);
+            gos_TerminateApplication();
+            promptToQuit = 0;
+        }
+        else if (LogisticsOKDialog::instance()->getStatus() == LogisticsScreen::NO)
+        {
+            if (LogisticsOKDialog::instance()->isDone())
+                promptToQuit = 0;
+        }
+    }
+    else if (bLegal)
+    {
+        LogisticsLegalDialog::instance()->update();
+        if (LogisticsLegalDialog::instance()->isDone())
+        {
+            LogisticsLegalDialog::instance()->end();
+            bLegal = 0;
+        }
+    }
+    else if (bHostLeftDlg)
+    {
+        LogisticsOneButtonDialog::instance()->update();
+        if (LogisticsOneButtonDialog::instance()->isDone())
+        {
+            LogisticsOneButtonDialog::instance()->end();
+            bHostLeftDlg = 0;
+        }
+        if (MPlayer)
+        {
+            MPlayer->closeSession();
+            delete MPlayer;
+            MPlayer = NULL;
+        }
+    }
+    else if (promptToDisconnect)
+    {
+        LogisticsOKDialog::instance()->update();
+        if (LogisticsOKDialog::instance()->isDone())
+        {
+            if (YES == LogisticsOKDialog::instance()->getStatus())
+            {
+                if (MPlayer)
+                {
+                    MPlayer->closeSession();
+                    delete MPlayer;
+                    MPlayer = NULL;
+                }
+                long oldRes = endResult;
+                endResult = 0;
+                handleMessage(oldRes, oldRes);
+                setDrawBackground(true);
+            }
+            else
+                handleMessage(NEXT, NEXT);
+            promptToDisconnect = 0;
+        }
+    }
+    else
+    {
+        if (bDrawBackground)
+        {
+            if (!intro.animObjects[0].isDone())
+            {
+                intro.update();
+                background.update();
+                if (userInput->getKeyDown(KEY_ESCAPE) || (Environment.Renderer == 3))
+                {
+                    introOver = true;
+                    userInput->mouseOn();
+                    soundSystem->playDigitalSample(LOG_MAINMENUBUTTON);
+                }
+                else if (!introOver)
+                    return;
+            }
+            else
+            {
+                background.update();
+                if (!introOver)
+                    soundSystem->playDigitalSample(LOG_MAINMENUBUTTON);
+                introOver = true;
+                userInput->mouseOn();
+            }
+        }
 
-	if ( bOptions )
-	{
-		OptionsScreenWrapper::status_type result = optionsScreenWrapper->update();
-		if (result == OptionsScreenWrapper::opt_DONE)
-		{
-			optionsScreenWrapper->end();
-			bOptions = 0;
-		}
-
-		return;
-	}
-
-	if ( (bSave || bLoad || bLoadCampaign) && endAnim.isDone() )
-	{
-		LogisticsSaveDialog::instance()->update();
-
-		if ( LogisticsSaveDialog::instance()->getStatus() == LogisticsScreen::YES 
-			&& LogisticsSaveDialog::instance()->isDone() )
-		{
-			
-			char name[1024];
-			strcpy( name, savePath );
-			strcat( name, LogisticsSaveDialog::instance()->getFileName() );
-			int index = strlen( name ) - 4;
-			if ( S_stricmp( &name[index], ".fit" ) !=0 ) 
-				strcat( name, ".fit" );
-
-			
-			FitIniFile file;
-			if ( bSave )
-			{
-				// make sure the save game directory exists, if not create it
-				CreateDirectory( savePath, NULL );
-
-				if ( NO_ERR != file.createWithCase( name ) )
-				{
-					char errorStr[1024];
-					sprintf( errorStr, "couldn't open the file %s", name );
-					Assert( 0, 0, errorStr );
-				}
-				else
-				{
-					LogisticsData::instance->save( file );
-					LogisticsSaveDialog::instance()->end();
-					file.close();
-				}
-				bSave = bLoad = 0;
-				status = NEXT;
-				
-
-			}
-			else if ( bLoadCampaign )
-			{
-				LogisticsData::instance->startNewCampaign( LogisticsSaveDialog::instance()->getFileName());
-				status = endResult = RESTART;
-//				background.beginFadeOut( 1.0f );
-//				beginFadeOut( 1.0f );
-				bLoadCampaign = 0;
-			}
-			else
-			{
-				const bool do_not_make_lower = true;
-				if ( NO_ERR != file.open( name, READ, 50, do_not_make_lower ) )
-				{
-					char errorStr[1024];
-					sprintf( errorStr, "couldn't open the file %s", name );
-					Assert( 0, 0, errorStr );
-				}
-				else
-					LogisticsData::instance->load( file );
-				LogisticsSaveDialog::instance()->end();
-				bSave = bLoad = 0;
-				status = RESTART;
-				file.close();
-
-			}
-		}
-		else if ( LogisticsSaveDialog::instance()->getStatus() == LogisticsScreen::NO &&
-			LogisticsSaveDialog::instance()->isDone())
-		{
-			LogisticsSaveDialog::instance()->end();
-			bSave = bLoad = bLoadCampaign = 0 ;
-			if ( !bDrawBackground )
-				status = NEXT;
-			else
-			{
-				beginAnim.begin();
-				endAnim.end();
-			}
-		}
-		return;
-	}
-	else if ( bLoadSingle && endAnim.isDone())
-	{
-		singleLoadDlg.update();
-		if ( singleLoadDlg.isDone() )
-		{
-			if ( singleLoadDlg.getStatus() == YES )
-			{
-				const char* pName = singleLoadDlg.getMapFileName();
-				if (pName)
-				{
-					LogisticsData::instance->setSingleMission( pName );
-					status = SKIPONENEXT;
-				}
-			}
-
-			bLoadSingle = 0;
-			beginAnim.begin();
-			endAnim.end();
-		}
-	}
-
-	else if ( promptToQuit )
-	{
-		LogisticsOKDialog::instance()->update();
-		{
-			if ( LogisticsOKDialog::instance()->getStatus() == LogisticsScreen::YES )
-			{
-				soundSystem->playDigitalSample( LOG_EXITGAME );
-				gos_TerminateApplication();
-				promptToQuit = 0;
-
-			}
-			else if ( LogisticsOKDialog::instance()->getStatus() == LogisticsScreen::NO)
-			{
-				if ( LogisticsOKDialog::instance()->isDone() )
-					promptToQuit = 0;
-			}
-
-			
-
-		}
-	}
-	else if ( bLegal )
-	{
-		LogisticsLegalDialog::instance()->update();
-		if ( LogisticsLegalDialog::instance()->isDone() )
-		{
-			LogisticsLegalDialog::instance()->end();
-			bLegal = 0;
-		}
-	}
-	else if ( bHostLeftDlg )
-	{
-		LogisticsOneButtonDialog::instance()->update();
-		if ( LogisticsOneButtonDialog::instance()->isDone() )
-		{
-			LogisticsOneButtonDialog::instance()->end();
-			bHostLeftDlg = 0;
-		}
-
-		if ( MPlayer ) // has to be done, but can't be done when initialized
-		{
-			MPlayer->closeSession();
-			delete MPlayer;
-			MPlayer = NULL;
-		}
-	}
-	else if ( promptToDisconnect )
-	{
-		LogisticsOKDialog::instance()->update();
-		if ( LogisticsOKDialog::instance()->isDone() )
-		{
-			if ( YES == LogisticsOKDialog::instance()->getStatus() )
-			{
-				if ( MPlayer )
-				{
-					MPlayer->closeSession();
-					delete MPlayer;
-					MPlayer = NULL;
-				}
-				long oldRes = endResult;
-				endResult = 0;
-
-				handleMessage( oldRes, oldRes );
-
-				setDrawBackground( true );
-			}
-			else
-				handleMessage( NEXT, NEXT );
-			
-			promptToDisconnect = 0;
-		}
-	}
-	else
-	{
-		if ( bDrawBackground  )
-		{
-			if ( !intro.animObjects[0].isDone() )
-			{
-				intro.update();
-				background.update();
-				if (userInput->getKeyDown(KEY_ESCAPE) || (Environment.Renderer == 3))
-				{
-					introOver = true;
-					userInput->mouseOn();
-					soundSystem->playDigitalSample( LOG_MAINMENUBUTTON );
-
-				}
-				else if ( !introOver )
-					return;
-			}
-			else
-			{
-				background.update();
-				if ( !introOver )
-					soundSystem->playDigitalSample( LOG_MAINMENUBUTTON );
-
-				introOver = true;
-				userInput->mouseOn();
-
-			}
-		}
-
-		beginAnim.update();
-		endAnim.update();
-
-		LogisticsScreen::update();
-		if ( (!bLoadSingle) && userInput->isLeftClick() && !inside( userInput->getMouseX(), userInput->getMouseY() ) )
-		{
-			handleMessage( 0, MM_MSG_RETURN_TO_GAME );
-		}
-	}
+        beginAnim.update();
+        endAnim.update();
+        LogisticsScreen::update();
+        if ((!bLoadSingle) && userInput->isLeftClick() && !inside(userInput->getMouseX(), userInput->getMouseY()))
+        {
+            handleMessage(0, MM_MSG_RETURN_TO_GAME);
+        }
+    }
 }
 
 void MainMenu::render()
 {
+    // If intro video is playing, just render the video and nothing else
+    if (introMP4Player && !videoFinished) {
+        introMP4Player->render();
+        return;
+    }
 
-	if (introMovie)
-	{
-		introMovie->render();
-		return;
-	}
-	if ( bDrawMechlopedia && (fadeTime > fadeOutTime || !fadeOutTime) )
-	{
-		mechlopedia->render();
-		return;
-	}
+    float scaleX = Environment.screenWidth / 1024.0f;
+    float scaleY = Environment.screenHeight / 768.0f;
+    float fontScale = std::min(scaleX, scaleY);
 
-	
-	if ( bOptions )
-	{
-		optionsScreenWrapper->render();
-		return;
-	}
+    if (bDrawMechlopedia && (fadeTime > fadeOutTime || !fadeOutTime))
+    {
+        mechlopedia->render();
+        return;
+    }
 
-	//DO NOT play the splash screen animation in software.
-	// WOW does it beat up the framerate!
-	float xDelta = 0.f;
-	float yDelta = 0.f;  
-	long color = 0xff000000;
+    if (bOptions)
+    {
+        optionsScreenWrapper->render();
+        return;
+    }
 
-	if (Environment.Renderer != 3)
-	{
+    float xDelta = 0.f;
+    float yDelta = 0.f;
+    long color = 0xff000000;
 
-		if ( beginAnim.isAnimating() && !beginAnim.isDone() )
-		{
-			xDelta = beginAnim.getXDelta();
-			yDelta = beginAnim.getYDelta();
+    if (Environment.Renderer != 3)
+    {
+        if (beginAnim.isAnimating() && !beginAnim.isDone())
+        {
+            xDelta = beginAnim.getXDelta();
+            yDelta = beginAnim.getYDelta();
+            float time = beginAnim.getCurrentTime();
+            float endTime = beginAnim.getMaxTime();
+            if (endTime)
+            {
+                color = interpolateColor(0x00000000, 0x7f000000, time / endTime);
+            }
+        }
+        else if (endAnim.isAnimating())
+        {
+            xDelta = endAnim.getXDelta();
+            yDelta = endAnim.getYDelta();
+            float time = endAnim.getCurrentTime();
+            float endTime = endAnim.getMaxTime();
+            if (endTime && (time <= endTime))
+            {
+                color = interpolateColor(0x7f000000, 0x00000000, time / endTime);
+            }
+        }
 
-			float time = beginAnim.getCurrentTime();
-			float endTime = beginAnim.getMaxTime();
-			if ( endTime )
-			{
-				color = interpolateColor( 0x00000000, 0x7f000000, time/endTime );
+        GUI_RECT rect = {0, 0, static_cast<long>(1024 * scaleX), static_cast<long>(768 * scaleY)};
+        drawRect(rect, color);
 
-			}
-		}
+        if (bDrawBackground)
+        {
+            background.render();
+            intro.render();
+            if (!intro.animObjects[0].isDone() && !introOver && !bHostLeftDlg)
+                return;
+        }
+    }
+    else
+    {
+        GUI_RECT rect = {0, 0, Environment.screenWidth, Environment.screenHeight};
+        drawRect(rect, color);
+    }
 
-		else if (endAnim.isAnimating() /*&& !endAnim.isDone()*/)
-		{
-			xDelta = endAnim.getXDelta();
-			yDelta = endAnim.getYDelta();
+    if (!xDelta && !yDelta)
+    {
+        long scaledX = static_cast<long>(textObjects[1].globalX() * scaleX);
+        long scaledTop = static_cast<long>(textObjects[1].globalTop() * scaleY);
+        long scaledRight = static_cast<long>(textObjects[1].globalRight() * scaleX);
+        long scaledBottom = static_cast<long>(textObjects[1].globalBottom() * scaleY);
+        long fontSize = static_cast<long>(textObjects[1].font.getSize() * fontScale);
 
-			float time = endAnim.getCurrentTime();
-			float endTime = endAnim.getMaxTime();
-			if ( endTime && (time <= endTime))
-			{
-				color = interpolateColor( 0x7f000000, 0x00000000, time/endTime );
-			}
-		}
+        const char* text = textObjects[1].text;
+        int textWidth = textObjects[1].font.width(text);
+        int centerX = Environment.screenWidth / 2;
+        int y = Environment.screenHeight - 24;
 
-		GUI_RECT rect = { 0, 0, Environment.screenWidth, Environment.screenHeight };
-		drawRect( rect, color );
+        float maxWidth = Environment.screenWidth * 0.9f;
+        float scale = 1.0f;
+        if (textWidth > maxWidth)
+            scale = maxWidth / (float)textWidth;
 
-		if ( bDrawBackground )
-		{
-			background.render();
-			intro.render();
-			if ( !intro.animObjects[0].isDone() && !introOver && !bHostLeftDlg )
-				return;
+        drawShadowText(
+            0xffc66600, 0xff000000, textObjects[1].font.getTempHandle(),
+            centerX - (textWidth * scale) / 2,
+            y,
+            centerX + (textWidth * scale) / 2,
+            y + 24,
+            true, text, false,
+            textObjects[1].font.getSize(), scale, scale);
+    }
 
+    textObjects[1].showGUIWindow(false);
 
-		}
-	}
-	else
-	{
-		GUI_RECT rect = { 0, 0, Environment.screenWidth, Environment.screenHeight };
-		drawRect( rect, color );
-	}
+    if ((!bSave && !bLoad && !bLoadSingle && !bLoadCampaign) || (!endAnim.isDone() && endResult != RESTART))
+        LogisticsScreen::render(xDelta, yDelta);
+    else if (bLoadSingle)
+        singleLoadDlg.render();
+    else
+        LogisticsSaveDialog::instance()->render();
 
-	if ( !xDelta && !yDelta )
-	{
-		drawShadowText( 0xffc66600, 0xff000000, textObjects[1].font.getTempHandle(), 
-			textObjects[1].globalX(), textObjects[1].globalTop(),
-			textObjects[1].globalRight(), textObjects[1].globalBottom(),
-			true, textObjects[1].text, false, textObjects[1].font.getSize(), 1, 1 );
-	}
-
-	textObjects[1].showGUIWindow( false );
-
-	
-	if ( (!bSave && !bLoad && !bLoadSingle && !bLoadCampaign) || (!endAnim.isDone() && endResult != RESTART ) )	
-		LogisticsScreen::render( xDelta, yDelta );
-	else if ( bLoadSingle )
-		singleLoadDlg.render();
-	else
-		LogisticsSaveDialog::instance()->render();
- 
-	if ( promptToQuit || promptToDisconnect )
-	{
-		LogisticsOKDialog::instance()->render();
-	}
-	if ( bLegal )
-	{
-		LogisticsLegalDialog::instance()->render();
-	}
-	if ( bHostLeftDlg )
-	{
-		LogisticsOneButtonDialog::instance()->render();
-	}
-
-
-
-	
+    if (promptToQuit || promptToDisconnect)
+        LogisticsOKDialog::instance()->render();
+    if (bLegal)
+        LogisticsLegalDialog::instance()->render();
+    if (bHostLeftDlg)
+        LogisticsOneButtonDialog::instance()->render();
 }
 
-void MainMenu::setHostLeftDlg( const char* playerName )
+void MainMenu::setHostLeftDlg(const char* playerName)
 {
-	char leaveStr[256];
-	char formatStr[256];
+    char leaveStr[256];
+    char formatStr[256];
+    cLoadString(IDS_PLAYER_LEFT, leaveStr, 255);
+    sprintf(formatStr, leaveStr, playerName);
 
-	cLoadString( IDS_PLAYER_LEFT, leaveStr, 255 );
-	sprintf( formatStr, leaveStr, playerName );
+    LogisticsOneButtonDialog::instance()->setText(IDS_PLAYER_LEFT, IDS_DIALOG_OK, IDS_DIALOG_OK);
+    LogisticsOneButtonDialog::instance()->setText(formatStr);
 
-	LogisticsOneButtonDialog::instance()->setText( IDS_PLAYER_LEFT,
-					IDS_DIALOG_OK, IDS_DIALOG_OK );
-	LogisticsOneButtonDialog::instance()->setText( formatStr );
-
-	if ( MPlayer && MPlayer->playerInfo[MPlayer->commanderID].booted )
-	{
-		LogisticsOneButtonDialog::instance()->setText( IDS_MP_PLAYER_KICKED,
-					IDS_DIALOG_OK, IDS_DIALOG_OK );
-
-	}
-	LogisticsOneButtonDialog::instance()->begin();
-	bHostLeftDlg = true;
-
+    if (MPlayer && MPlayer->playerInfo[MPlayer->commanderID].booted)
+    {
+        LogisticsOneButtonDialog::instance()->setText(IDS_MP_PLAYER_KICKED, IDS_DIALOG_OK, IDS_DIALOG_OK);
+    }
+    LogisticsOneButtonDialog::instance()->begin();
+    bHostLeftDlg = true;
 }
 
+void MainMenu::restoreOpenGLState()
+{
+    SDL_Window* gameWindow = SDL_GL_GetCurrentWindow();
+    SDL_GLContext gameContext = SDL_GL_GetCurrentContext();
+    if (SDL_GL_MakeCurrent(gameWindow, gameContext) != 0)
+    {
+        std::cerr << "[MainMenu] Failed to restore OpenGL context: " << SDL_GetError() << "\n";
+    }
 
-
-
-//*************************************************************************************************
-// end of file ( MainMenu.cpp )
+    glViewport(0, 0, Environment.screenWidth, Environment.screenHeight);
+    glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+    glEnable(GL_DEPTH_TEST);
+    glDisable(GL_BLEND);
+    glMatrixMode(GL_PROJECTION);
+    glLoadIdentity();
+    glOrtho(0, Environment.screenWidth, Environment.screenHeight, 0, -1, 1);
+    glMatrixMode(GL_MODELVIEW);
+    glLoadIdentity();
+    std::cout << "[MainMenu] Restored OpenGL state\n";
+}

--- a/code/mainmenu.h
+++ b/code/mainmenu.h
@@ -1,115 +1,79 @@
 #ifndef MAINMENU_H
 #define MAINMENU_H
-/*************************************************************************************************\
-MainMenu.h			: Interface for the MainMenu component.
-//---------------------------------------------------------------------------//
-// Copyright (C) Microsoft Corporation. All rights reserved.                 //
-//===========================================================================//
-\*************************************************************************************************/
 
 #ifndef LOGISTICSSCREEN_H
-#include"logisticsscreen.h"
+#include "logisticsscreen.h"
 #endif
 
 #ifndef AANIM_H
-#include"aanim.h"
+#include "aanim.h"
 #endif
 
 #ifndef MPLOADMAP_H
-#include"mploadmap.h"
+#include "mploadmap.h"
 #endif
 
-#ifndef MC2movie_H
-#include"mc2movie.h"
+#ifndef MP4PLAYER_H
+#include "mp4player.h"
 #endif
-
 
 class OptionsScreenWrapper;
 class Mechlopedia;
-//*************************************************************************************************
 
-/**************************************************************************************************
-CLASS DESCRIPTION
-MainMenu:
-**************************************************************************************************/
 class SplashIntro : public LogisticsScreen
 {
 public:
-
-	SplashIntro(){}
-	virtual ~SplashIntro(){}
-
-	void init();
-
+    SplashIntro() {}
+    virtual ~SplashIntro() {}
+    void init();
 };
 
-
-class MainMenu: public LogisticsScreen
+class MainMenu : public LogisticsScreen
 {
-	public:
+public:
+    MainMenu();
+    virtual ~MainMenu();
+    int init(FitIniFile& file);
+    virtual void begin();
+    virtual void end();
+    virtual void update();
+    virtual void render();
+    void restoreOpenGLState();
+    void setHostLeftDlg(const char* playerName);
+    void setDrawBackground(bool bDrawBackground);
+    void skipIntro();
+    virtual int handleMessage(unsigned long, unsigned long);
+    static bool bDrawMechlopedia;
 
-		MainMenu();
-		virtual ~MainMenu();
+private:
+    MainMenu& operator=(const MainMenu& ainMenu);
+    MainMenu(const MainMenu& src);
 
+    bool bDrawBackground;
+    LogisticsScreen background;
+    bool promptToQuit;
+    bool bOptions;
+    bool bSave;
+    bool bLoad;
+    bool bLoadSingle;
+    bool bLoadCampaign;
+    bool promptToDisconnect;
+    bool bLegal;
+    bool videoFinished;
+    int currentVideoIndex; // Track which video in sequence we're playing
 
-		int init( FitIniFile& file );
-
-		virtual void begin();
-		virtual void end();
-		virtual void update();
-		virtual void render();
-
-		void setHostLeftDlg( const char* playerName );
-
-		void setDrawBackground( bool bDrawBackground );
-		void skipIntro();
-
-		virtual int	handleMessage( unsigned long, unsigned long );
-		
-
-		static	bool	bDrawMechlopedia;
-
-	private:
-
-		MainMenu& operator=( const MainMenu& ainMenu );
-		MainMenu( const MainMenu& src );
-
-
-
-		bool	bDrawBackground;
-
-		LogisticsScreen	background;
-
-		bool	promptToQuit;
-		bool	bOptions;
-		bool	bSave;
-		bool	bLoad;
-		bool	bLoadSingle;
-		bool	bLoadCampaign;
-		bool	promptToDisconnect;
-		bool	bLegal;
-
-		long	tuneId;			//What music should I play here!
-		bool	musicStarted;	//Should I restart the tune?
-
-		long	endResult;
-
-		aAnimation	beginAnim;
-		aAnimation	endAnim;
-
-		OptionsScreenWrapper*	optionsScreenWrapper;
-		Mechlopedia*			mechlopedia;
-		SplashIntro				intro;
-		bool					introOver;
-		MPLoadMap				singleLoadDlg;
-		bool					bHostLeftDlg;
-
-		MC2MoviePtr			introMovie;
-			
-		
-
+    long tuneId;
+    bool musicStarted;
+    long endResult;
+    aAnimation beginAnim;
+    aAnimation endAnim;
+    OptionsScreenWrapper* optionsScreenWrapper;
+    Mechlopedia* mechlopedia;
+    SplashIntro intro;
+    bool introOver;
+    MPLoadMap singleLoadDlg;
+    bool bHostLeftDlg;
+    MP4Player* introMP4Player;
 };
 
-
-//*************************************************************************************************
-#endif  // end of file ( MainMenu.h )
+#endif

--- a/code/mechcmd2.cpp
+++ b/code/mechcmd2.cpp
@@ -280,9 +280,14 @@ float trisPerSecond[MAX_HARDWARE_CARDS] =
 extern bool loadInMissionSave;
 extern char CDInstallPath[];
 
-extern float averageFrameRate;
+/*extern float averageFrameRate;
 extern long currentFrameNum;
-extern float last30Frames[];
+extern float last30Frames[];*/
+
+float averageFrameRate = 0.0f;
+long currentFrameNum = 0;
+float last30Frames[30] = { 0.0f };
+
 
 extern bool WindowsNT;
 

--- a/code/mechicon.cpp
+++ b/code/mechicon.cpp
@@ -15,6 +15,7 @@ MechIcon.cpp			: Implementation of the MechIcon component.
 #include"controlgui.h"
 #include"gamesound.h"
 #include"platform_windows.h"
+#include <iostream>
 
 #ifndef MISSION_H
 #include"mission.h"
@@ -30,7 +31,6 @@ TGAFileHeader* ForceGroupIcon::s_textureMemory = 0;
 
 StaticInfo*		ForceGroupIcon::jumpJetIcon = NULL;
 
-MC2MoviePtr	ForceGroupIcon::bMovie = NULL;
 DWORD ForceGroupIcon::pilotVideoTexture = 0;
 MechWarrior*	ForceGroupIcon::pilotVideoPilot = NULL;
 
@@ -108,6 +108,7 @@ ForceGroupIcon::ForceGroupIcon(  )
 	bDrawBack = 0;
 	backDamageIndex = -1;
 	damageIconIndex = 0;
+	bMovie = NULL;
 
 	locationIndex = 0;
 
@@ -177,16 +178,18 @@ void ForceGroupIcon::swapResolutions( bool bForce )
 
 ForceGroupIcon::~ForceGroupIcon()
 {
-
-	if (pilotVideoPilot && pilotVideoPilot == unit->getPilot() )
+	// If we own the current pilot video, free it and clear the shared
+	// identifiers so setPilotVideo() does not try to match our now-dead pilot.
+	// Per-instance ownership means no cross-icon pilot check is needed — only
+	// the owning icon has a non-null bMovie. This drops the old
+	// `unit->getPilot()` dereference, which was unsafe if unit had already been
+	// torn down.
+	if ( bMovie )
 	{
-		if ( bMovie )
-		{
-			delete bMovie;
-			bMovie = NULL;
-			pilotVideoTexture = 0;
-		}
+		delete bMovie;
+		bMovie = NULL;
 		pilotVideoPilot = NULL;
+		pilotVideoTexture = 0;
 	}
 	s_slotUsed[damageIconIndex] = 0;
 
@@ -641,12 +644,7 @@ void MechIcon::update()
 
 	if (bMovie)
 	{
-		bool result = bMovie->update();
-		if (result)
-		{
-			delete bMovie;
-			bMovie = NULL;
-		}
+		bMovie->update();
 	}
 
 	if (unit->body[MECH_BODY_LOCATION_LTORSO].damageState == IS_DAMAGE_DESTROYED)
@@ -970,7 +968,6 @@ void ForceGroupIcon::render()
 			}
 			else
 			{
-				bMovie->setRect(vRect);
 				bMovie->render();
 			}
 		}
@@ -1017,8 +1014,6 @@ void ForceGroupIcon::render()
 	{
 		drawDeathEffect();
 	}
-
-
 }
 
 void ForceGroupIcon::renderUnitIcon( float left, float top, float right, float bottom )

--- a/code/mechicon.h
+++ b/code/mechicon.h
@@ -15,8 +15,8 @@ MechIcon.h			: Interface for the MechIcon component.
 #include"afont.h"
 #endif
 
-#ifndef MC2movie_H
-#include"mc2movie.h"
+#ifndef MP4PLAYER_H
+#include"mp4player.h"
 #endif
 
 //*************************************************************************************************
@@ -156,7 +156,12 @@ protected:
 
 		float		msgPlayTime;
 
-		static		MC2MoviePtr 	bMovie;
+		// Per-instance; at any given time at most one icon has this non-null.
+		// Invariant owned by ForceGroupBar::setPilotVideo() — the only licensed
+		// creator, which walks all icons to clean up before allocating a new one.
+		// Do not assign to this outside setPilotVideo() unless that invariant is
+		// preserved.
+		MP4Player*	bMovie;
 		static		DWORD			pilotVideoTexture;
 		static		MechWarrior*	pilotVideoPilot;
 		

--- a/code/missionselectionscreen.cpp
+++ b/code/missionselectionscreen.cpp
@@ -14,6 +14,8 @@ MissionSelectionScreen.cpp			: Implementation of the MissionSelectionScreen comp
 #include"sounds.h"
 #include"mc2movie.h"
 #include"gamesound.h"
+#include <SDL2/SDL.h>
+#include <iostream>  // Add this for std::cerr
 
 #define VIDEO_RECT 7
 #define MAP_RECT 3
@@ -79,39 +81,41 @@ void MissionSelectionScreen::render(int xOffset, int yOffset )
 	if ( xOffset == 0 && yOffset == 0 )
 		missionDescriptionListBox.render();
 
-	//Renders the movie the old way.
-	//movie Now!
 	LogisticsScreen::render( xOffset, yOffset );
-	if ( !xOffset && !yOffset )
+	if ( !xOffset && !yOffset && bMovie && bMovie->isPlaying() && bMovie->getTextureHandle() )
 	{
-		/*
+		// Restored from the original commented-out block (pre-open-source).
+		// Per FMV_DESIGN.md §5: argb MUST be 0xffffffff (the gos_tex_vertex
+		// fragment shader multiplies vertex color into the sampled texel).
 		gos_VERTEX v[4];
 
-		for( int i = 0; i < 4; i++ )
+		for ( int i = 0; i < 4; i++ )
 		{
 			v[i].argb = 0xffffffff;
 			v[i].frgb = 0;
 			v[i].rhw = .5;
 			v[i].u = 0.f;
 			v[i].v = 0.f;
-			v[i].x = rects[VIDEO_RECT].left()+1 + xOffset;
-			v[i].y = rects[VIDEO_RECT].top()+1 + yOffset;
+			v[i].x = rects[VIDEO_RECT].left() + 1 + xOffset;
+			v[i].y = rects[VIDEO_RECT].top()  + 1 + yOffset;
 			v[i].z = 0.f;
 		}
 
-		v[2].x = v[3].x = v[0].x + rects[VIDEO_RECT].width()-2;
-		v[2].y = v[1].y = v[0].y + rects[VIDEO_RECT].height()-2;
+		v[2].x = v[3].x = v[0].x + rects[VIDEO_RECT].width()  - 2;
+		v[2].y = v[1].y = v[0].y + rects[VIDEO_RECT].height() - 2;
 
 		v[2].u = v[3].u = 1.0f;
 		v[2].v = v[1].v = 1.0f;
 
-		gos_SetRenderState( gos_State_Texture,  videoTexture );
+		// State discipline note: gos render state is a global state machine,
+		// not a stack — gos_State_AlphaMode set here leaks to whatever
+		// gos_DrawQuads runs next. Each subsequent UI element must set the
+		// alpha mode it needs; we do not restore here.
+		gos_SetRenderState( gos_State_Texture,   bMovie->getTextureHandle() );
+		gos_SetRenderState( gos_State_Filter,    gos_FilterNone );
+		gos_SetRenderState( gos_State_AlphaMode, gos_Alpha_OneZero );
 		gos_DrawQuads( v, 4 );
-		gos_SetRenderState( gos_State_Texture,  0 );
-		*/
-
-		if (bMovie)
-			bMovie->render();
+		gos_SetRenderState( gos_State_Texture,   0 );
 	}
 
 
@@ -228,18 +232,24 @@ void MissionSelectionScreen::begin()
 
 	
 	str = LogisticsData::instance->getCurrentVideoFileName();
+	std::cout << "[MissionSelectionScreen] Current video filename: " << (str ? str : "NULL") << "\n";
 	if ( str && strlen( str ) )
 	{
-		FullPathFileName videoName;
-		videoName.init( moviePath, str, ".bik" );
+		FullPathFileName movieName;
+		//videoName.init( moviePath, str, ".bik" );
+		movieName.init( moviePath, str, ".mp4" );
+		std::cout << "[MissionSelectionScreen] Full movie path: " << (const char*)movieName << "\n";
 
-		if (fileExists(videoName) || fileExistsOnCD(videoName))
+		if (fileExists(movieName) || fileExistsOnCD(movieName))
 		{
+			std::cout << "[MissionSelectionScreen] Video file found, creating movie\n";
 			RECT movieRect;
 			movieRect.left = rects[VIDEO_RECT].left()+1;
 			movieRect.top = rects[VIDEO_RECT].top()+1;
 			movieRect.right = movieRect.left + rects[VIDEO_RECT].width()-2;
 			movieRect.bottom = movieRect.top + rects[VIDEO_RECT].height()-2;
+			std::cout << "[MissionSelectionScreen] Movie rect: " << movieRect.left << "," << movieRect.top 
+			          << " " << (movieRect.right - movieRect.left) << "x" << (movieRect.bottom - movieRect.top) << "\n";
 		
 			//If there is one already here, cause we loaded a savegame or something,
 			// Toss it to prevent leaking from the system Heap!
@@ -250,9 +260,9 @@ void MissionSelectionScreen::begin()
 				bMovie = NULL;
 			}
 
-			bMovie = new MC2Movie;
-			bMovie->init(videoName,movieRect,true);
-
+			bMovie = new MC2Movie();
+			RECT convertedRect = { movieRect.left, movieRect.top, movieRect.right, movieRect.bottom };
+			bMovie->init( (const char*)movieName, convertedRect, true );
 			if (Environment.Renderer == 3)
 			{
 				//DO NOT show the movies by default in software.
@@ -362,19 +372,14 @@ int MissionSelectionScreen::handleMessage( unsigned long msg, unsigned long who 
 		bStop = true;
 		break;
 
-	case MN_MSG_PAUSE:
-		if ( !getButton( who )->isPressed() )
+		case MN_MSG_PAUSE:
+		// MC2Movie has no pause() — see FMV_DESIGN.md §2.2. The button
+		// remains for visual continuity but no longer affects playback.
+		if ( bMovie )
 		{
-			if ( bMovie )
-				bMovie->pause(0);
-			getButton( who )->press(false);
+			getButton(who)->toggle();
 		}
-		else
-		{
-			if ( bMovie )
-				bMovie->pause(1);
-			getButton( who )->press(true);
-		}
+		break;
 
 
 		break;

--- a/code/missionselectionscreen.h
+++ b/code/missionselectionscreen.h
@@ -16,9 +16,7 @@ MissionSelectionScreen.h : Header file for mission selection
 #include"alistbox.h"
 #endif
 
-#ifndef MC2movie_H
-#include"mc2movie.h"
-#endif
+class MC2Movie;
 
 class FitIniFile;
 
@@ -43,7 +41,7 @@ private:
 
 	LogisticsScreen	operationScreen;
 
-	MC2MoviePtr		bMovie;
+	MC2Movie*		bMovie;
 	bool				playedLogisticsTune;
 
 	//HGOSVIDEO			video;

--- a/code/mp4player.cpp
+++ b/code/mp4player.cpp
@@ -1,16 +1,15 @@
 #define NOMINMAX
-#include "mc2movie.h"
+#include "mp4player.h"
 #include "gameos.hpp"
 #include <iostream>
 #include <algorithm>
 #include <GL/gl.h>
 
 // =========================================================================
-// Audio callback — drains PCM queue, updates master clock.
-// Cloned from MP4Player::audioCallback. Distinct symbol on purpose.
+// Audio callback — drains PCM queue, updates master clock
 // =========================================================================
-void MC2Movie::audioCallback(void* userdata, Uint8* stream, int len) {
-    auto* p = static_cast<MC2Movie*>(userdata);
+void MP4Player::audioCallback(void* userdata, Uint8* stream, int len) {
+    auto* p = static_cast<MP4Player*>(userdata);
     std::lock_guard<std::mutex> lock(p->audioMutex);
 
     int written = 0;
@@ -40,35 +39,35 @@ void MC2Movie::audioCallback(void* userdata, Uint8* stream, int len) {
 // =========================================================================
 // Constructor / Destructor
 // =========================================================================
-MC2Movie::MC2Movie()
+MP4Player::MP4Player(const std::string& path, SDL_Window* window, SDL_GLContext context)
     : fmtCtx(nullptr), vidCtx(nullptr), audCtx(nullptr),
       decFrame(nullptr), rgbFrame(nullptr), rgbBuf(nullptr), rgbBufSize(0),
       swsCtx(nullptr), swrCtx(nullptr), vidIdx(-1), audIdx(-1),
       vidTimeBase(0), audTimeBase(0), frameDur(1.0/24.0), vidW(0), vidH(0),
-      frameRate(0),
       audFrame(nullptr), audioDevice(0), sampleRate(0), channels(0),
       hasAudio(false), audioStarted(false),
-      gosTextureHandle(0), textureReady(false),
+      textureID(0), textureReady(false), sdlWindow(window), glContext(context),
       pendingData(nullptr), pendingPts(-1), hasPending(false),
-      displayRect{}, playing(false),
+      displayRect{}, moviePath(path), playing(false), paused(false),
       looped(false), demuxEof(false), clockRunning(false),
-      frameCount(0), perfFreq(0), startCounter(0)
+      frameCount(0), frameRate(0), perfFreq(0), startCounter(0)
 {
     perfFreq = SDL_GetPerformanceFrequency();
+    openFile(path);
 }
 
-MC2Movie::~MC2Movie() {
+MP4Player::~MP4Player() {
     cleanup();
 }
 
 // =========================================================================
-// Open file, find streams, init decoders.
+// Open file, find streams, init decoders
 // =========================================================================
-void MC2Movie::openFile(const std::string& path) {
+void MP4Player::openFile(const std::string& path) {
     moviePath = path;
 
     if (avformat_open_input(&fmtCtx, path.c_str(), nullptr, nullptr) < 0) {
-        std::cerr << "[MC2Movie] Cannot open: " << path << "\n";
+        std::cerr << "[MP4Player] Cannot open: " << path << "\n";
         return;
     }
     avformat_find_stream_info(fmtCtx, nullptr);
@@ -98,9 +97,13 @@ void MC2Movie::openFile(const std::string& path) {
 
         decFrame = av_frame_alloc();
         rgbFrame = av_frame_alloc();
-        // sws_scale SIMD tail-overrun guard. See mp4player.cpp for full
-        // rationale. Briefings are typically 1920-wide (SIMD-safe) but the
-        // guard is cheap and keeps the pattern consistent across all players.
+        // sws_scale with SWS_BILINEAR uses SIMD that overruns the last row's
+        // tail by up to ~32 bytes on SIMD-unfriendly widths (e.g. 76-px pilot
+        // portrait clips). Keep align=1 so linesize is packed (downstream
+        // memcpy and glTexSubImage2D assume packed rows), but allocate a tail
+        // guard so the overrun lands in harmless memory. Pre-fix, this bug
+        // manifested as STATUS_HEAP_CORRUPTION detected on the next heap op
+        // (often inside SDL_GL_SwapWindow).
         const int SWS_TAIL_GUARD = 64;
         rgbBufSize = av_image_get_buffer_size(AV_PIX_FMT_RGBA, vidW, vidH, 1);
         rgbBuf = new uint8_t[rgbBufSize + SWS_TAIL_GUARD];
@@ -108,7 +111,7 @@ void MC2Movie::openFile(const std::string& path) {
                              AV_PIX_FMT_RGBA, vidW, vidH, 1);
         pendingData = new uint8_t[rgbBufSize + SWS_TAIL_GUARD];
 
-        std::cout << "[MC2Movie] Video: " << vidW << "x" << vidH
+        std::cout << "[MP4Player] Video: " << vidW << "x" << vidH
                   << " @ " << frameRate << " FPS\n";
     }
 
@@ -151,42 +154,56 @@ void MC2Movie::openFile(const std::string& path) {
         audioDevice = SDL_OpenAudioDevice(nullptr, 0, &want, &audioSpec, 0);
         if (audioDevice > 0) {
             hasAudio = true;
-            std::cout << "[MC2Movie] Audio: " << sampleRate << " Hz, "
+            std::cout << "[MP4Player] Audio: " << sampleRate << " Hz, "
                       << channels << " ch\n";
         }
     }
 }
 
 // =========================================================================
-// init — open file, allocate gos texture at video dimensions, start playback.
+// init — called by game code to set display rect and start playback
 // =========================================================================
-bool MC2Movie::init(const char* path, RECT rect, bool loop) {
+void MP4Player::init(const char* path, RECT rect, bool loop,
+                     SDL_Window* window, SDL_GLContext context) {
     displayRect = rect;
     looped = loop;
+    if (window) sdlWindow = window;
+    if (context) glContext = context;
 
-    if (path && (!fmtCtx || moviePath != path)) {
+    // Reopen if different file
+    if (path && moviePath != path && !fmtCtx) {
         openFile(path);
     }
 
-    if (!fmtCtx || !vidCtx || vidW <= 0 || vidH <= 0) {
-        return false;
-    }
-
-    if (gosTextureHandle == 0) {
-        gosTextureHandle = gos_NewEmptyTexture(
-            gos_Texture_Alpha, "MC2Movie",
-            RECT_TEX(vidW, vidH), 0);
-        textureReady = (gosTextureHandle != 0);
-    }
-
+    initTexture();
     restart();
-    return true;
+}
+
+void MP4Player::initTexture() {
+    if (!sdlWindow || !glContext) return;
+    if (vidW == 0 || vidH == 0) return;
+
+    SDL_GL_MakeCurrent(sdlWindow, glContext);
+
+    if (textureID) {
+        glDeleteTextures(1, &textureID);
+        textureID = 0;
+    }
+
+    glGenTextures(1, &textureID);
+    glBindTexture(GL_TEXTURE_2D, textureID);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, vidW, vidH, 0,
+                 GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glBindTexture(GL_TEXTURE_2D, 0);
+    textureReady = true;
 }
 
 // =========================================================================
 // cleanup
 // =========================================================================
-void MC2Movie::cleanup() {
+void MP4Player::cleanup() {
     if (audioDevice) {
         SDL_PauseAudioDevice(audioDevice, 1);
         SDL_CloseAudioDevice(audioDevice);
@@ -208,8 +225,7 @@ void MC2Movie::cleanup() {
     delete[] pendingData; pendingData = nullptr;
     delete[] rgbBuf; rgbBuf = nullptr;
 
-    if (gosTextureHandle) { gos_DestroyTexture(gosTextureHandle); gosTextureHandle = 0; }
-    textureReady = false;
+    if (textureID) { glDeleteTextures(1, &textureID); textureID = 0; }
     if (swsCtx) { sws_freeContext(swsCtx); swsCtx = nullptr; }
     if (swrCtx) { swr_free(&swrCtx); swrCtx = nullptr; }
     if (decFrame) { av_frame_free(&decFrame); }
@@ -225,7 +241,7 @@ void MC2Movie::cleanup() {
 // =========================================================================
 // getClock — audio master, wall clock fallback
 // =========================================================================
-double MC2Movie::getClock() {
+double MP4Player::getClock() {
     if (hasAudio && audioStarted) return audioClock.load();
     if (clockRunning) return (double)(SDL_GetPerformanceCounter() - startCounter) / (double)perfFreq;
     return 0.0;
@@ -234,7 +250,7 @@ double MC2Movie::getClock() {
 // =========================================================================
 // demux — read packets from file, route to queues
 // =========================================================================
-void MC2Movie::demux() {
+void MP4Player::demux() {
     if (demuxEof) return;
 
     int audioPcmSize;
@@ -287,11 +303,9 @@ void MC2Movie::demux() {
 }
 
 // =========================================================================
-// decodeVideo — pop from video packet queue, decode until we have a frame.
-// Upload targets the gos texture's underlying GL id; no other GL state is
-// touched (gos owns viewport, scissor, blend, depth, pixel-storage, texenv).
+// decodeVideo — pop from video packet queue, decode until we have a frame
 // =========================================================================
-void MC2Movie::decodeVideo() {
+void MP4Player::decodeVideo() {
     static bool firstFrameLogged = false;
     while (!hasPending && !vidPktQueue.empty()) {
         AVPacket* pkt = vidPktQueue.front();
@@ -308,28 +322,27 @@ void MC2Movie::decodeVideo() {
                 double clock = getClock();
 
                 if (!clockRunning || framePts <= clock + 0.005) {
+                    // Due now — upload to texture
                     if (textureReady) {
-                        // Sanitize pixel-store state — the game's GL context
-                        // may have left GL_UNPACK_ROW_LENGTH non-zero or
-                        // alignment non-1 from an earlier texture upload,
-                        // which would skew every row of our RGBA data.
                         glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
                         glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
-                        glBindTexture(GL_TEXTURE_2D, gos_GetTextureGLId(gosTextureHandle));
+                        glBindTexture(GL_TEXTURE_2D, textureID);
                         glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, vidW, vidH,
                                         GL_RGBA, GL_UNSIGNED_BYTE, rgbFrame->data[0]);
+                        glBindTexture(GL_TEXTURE_2D, 0);
                     }
                     frameCount++;
                     if (!firstFrameLogged) {
                         firstFrameLogged = true;
-                        std::cout << "[MC2Movie] First frame decoded: PTS=" << framePts
-                                  << " texReady=" << textureReady
-                                  << " gosTex=" << gosTextureHandle
+                        std::cout << "[MP4Player] First frame decoded: PTS=" << framePts
+                                  << " texReady=" << textureReady << " texID=" << textureID
                                   << " " << vidW << "x" << vidH << "\n";
                     }
 
+                    // Frame drop if behind
                     if (clockRunning && framePts < clock - frameDur) continue;
                 } else {
+                    // Future frame — buffer
                     memcpy(pendingData, rgbFrame->data[0], rgbBufSize);
                     pendingPts = framePts;
                     hasPending = true;
@@ -347,8 +360,9 @@ void MC2Movie::decodeVideo() {
 // =========================================================================
 // update — main per-frame call from game loop
 // =========================================================================
-void MC2Movie::update() {
-    if (!playing) return;
+void MP4Player::update() {
+    if (!playing || paused) return;
+    if (sdlWindow && glContext) SDL_GL_MakeCurrent(sdlWindow, glContext);
 
     // Step 1: Demux packets into queues
     demux();
@@ -362,7 +376,7 @@ void MC2Movie::update() {
             SDL_PauseAudioDevice(audioDevice, 0);
             audioStarted = true;
             clockRunning = true;
-            std::cout << "[MC2Movie] Audio started (queue: " << qsz
+            std::cout << "[MP4Player] Audio started (queue: " << qsz
                       << ", vidPkts: " << vidPktQueue.size() << ")\n";
         }
     }
@@ -373,22 +387,14 @@ void MC2Movie::update() {
 
     // Step 3: Check pending video frame
     double clock = getClock();
-    if (frameCount > 0 && frameCount % 30 == 0) {
-        static int lastLog = -1;
-        if (frameCount != lastLog) {
-            lastLog = frameCount;
-            int aq; { std::lock_guard<std::mutex> lock(audioMutex); aq = (int)audPcmQueue.size(); }
-            std::cout << "[MC2Movie] Frame " << frameCount << " | clock: " << clock
-                      << "s | aq: " << aq << " | vq: " << vidPktQueue.size() << "\n";
-        }
-    }
     if (hasPending && pendingPts <= clock + 0.005) {
         if (textureReady) {
             glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
             glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
-            glBindTexture(GL_TEXTURE_2D, gos_GetTextureGLId(gosTextureHandle));
+            glBindTexture(GL_TEXTURE_2D, textureID);
             glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, vidW, vidH,
                             GL_RGBA, GL_UNSIGNED_BYTE, pendingData);
+            glBindTexture(GL_TEXTURE_2D, 0);
         }
         frameCount++;
         hasPending = false;
@@ -403,6 +409,7 @@ void MC2Movie::update() {
         { std::lock_guard<std::mutex> lock(audioMutex); qsz = (int)audPcmQueue.size(); }
         if (qsz == 0) {
             if (looped) {
+                // Seek back to start
                 av_seek_frame(fmtCtx, -1, 0, AVSEEK_FLAG_BACKWARD);
                 if (vidCtx) avcodec_flush_buffers(vidCtx);
                 if (audCtx) avcodec_flush_buffers(audCtx);
@@ -418,12 +425,124 @@ void MC2Movie::update() {
 }
 
 // =========================================================================
+// render — draw current texture to displayRect
+// =========================================================================
+void MP4Player::render() {
+    if (!textureReady || !textureID || vidW == 0) return;
+
+    // Game uses logical coordinates (e.g. 800x600) but window may be larger.
+    // Map display rect from game coords to physical window pixels.
+    int windowW, windowH;
+    SDL_GL_GetDrawableSize(sdlWindow, &windowW, &windowH);
+
+    int logicalW = Environment.screenWidth > 0 ? Environment.screenWidth : windowW;
+    int logicalH = Environment.screenHeight > 0 ? Environment.screenHeight : windowH;
+    float scaleX = (float)windowW / logicalW;
+    float scaleY = (float)windowH / logicalH;
+
+    float physLeft   = displayRect.left   * scaleX;
+    float physTop    = displayRect.top    * scaleY;
+    float physRight  = displayRect.right  * scaleX;
+    float physBottom = displayRect.bottom * scaleY;
+    float physW = physRight - physLeft;
+    float physH = physBottom - physTop;
+
+    // Save GL state
+    GLint savedViewport[4];
+    glGetIntegerv(GL_VIEWPORT, savedViewport);
+    GLboolean savedBlend = glIsEnabled(GL_BLEND);
+    GLboolean savedTex2d = glIsEnabled(GL_TEXTURE_2D);
+    GLboolean savedDepth = glIsEnabled(GL_DEPTH_TEST);
+    GLboolean savedScissor = glIsEnabled(GL_SCISSOR_TEST);
+    GLint savedMatrixMode;
+    glGetIntegerv(GL_MATRIX_MODE, &savedMatrixMode);
+    GLint savedActiveTex;
+    glGetIntegerv(GL_ACTIVE_TEXTURE, &savedActiveTex);
+    GLint savedTexEnvMode;
+    glGetTexEnviv(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, &savedTexEnvMode);
+    GLint savedUnpackAlign, savedUnpackRowLen;
+    glGetIntegerv(GL_UNPACK_ALIGNMENT, &savedUnpackAlign);
+    glGetIntegerv(GL_UNPACK_ROW_LENGTH, &savedUnpackRowLen);
+
+    // Set up clean GL state for video rendering
+    glViewport(0, 0, windowW, windowH);
+    glActiveTexture(GL_TEXTURE0);
+    glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+    glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
+
+    // Scissor to clip to physical rect (GL uses bottom-left origin)
+    glEnable(GL_SCISSOR_TEST);
+    glScissor((int)physLeft, windowH - (int)physBottom, (int)physW, (int)physH);
+
+    glDisable(GL_DEPTH_TEST);
+    glDisable(GL_BLEND);
+
+    // Aspect-preserving fit within physical rect
+    float vidAspect = (float)vidW / vidH;
+    float rectAspect = physW / physH;
+    float scaledW, scaledH;
+    float offX = physLeft, offY = physTop;
+
+    if (vidAspect > rectAspect) {
+        scaledW = physW;
+        scaledH = physW / vidAspect;
+        offY += (physH - scaledH) / 2;
+    } else {
+        scaledH = physH;
+        scaledW = physH * vidAspect;
+        offX += (physW - scaledW) / 2;
+    }
+
+    // Top-left origin projection in physical window pixels
+    glMatrixMode(GL_PROJECTION);
+    glPushMatrix();
+    glLoadIdentity();
+    glOrtho(0, windowW, windowH, 0, -1, 1);
+    glMatrixMode(GL_MODELVIEW);
+    glPushMatrix();
+    glLoadIdentity();
+
+    // Draw video quad
+    glEnable(GL_TEXTURE_2D);
+    glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_REPLACE);
+    glBindTexture(GL_TEXTURE_2D, textureID);
+
+    glBegin(GL_QUADS);
+    glTexCoord2f(0, 0); glVertex2f(offX, offY);
+    glTexCoord2f(1, 0); glVertex2f(offX + scaledW, offY);
+    glTexCoord2f(1, 1); glVertex2f(offX + scaledW, offY + scaledH);
+    glTexCoord2f(0, 1); glVertex2f(offX, offY + scaledH);
+    glEnd();
+
+    // Restore all GL state
+    glBindTexture(GL_TEXTURE_2D, 0);
+    glDisable(GL_TEXTURE_2D);
+    glDisable(GL_SCISSOR_TEST);
+    glMatrixMode(GL_PROJECTION);
+    glPopMatrix();
+    glMatrixMode(GL_MODELVIEW);
+    glPopMatrix();
+
+    glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, savedTexEnvMode);
+    glActiveTexture(savedActiveTex);
+    glPixelStorei(GL_UNPACK_ALIGNMENT, savedUnpackAlign);
+    glPixelStorei(GL_UNPACK_ROW_LENGTH, savedUnpackRowLen);
+    if (savedBlend) glEnable(GL_BLEND); else glDisable(GL_BLEND);
+    if (savedTex2d) glEnable(GL_TEXTURE_2D); else glDisable(GL_TEXTURE_2D);
+    if (savedDepth) glEnable(GL_DEPTH_TEST); else glDisable(GL_DEPTH_TEST);
+    if (savedScissor) glEnable(GL_SCISSOR_TEST); else glDisable(GL_SCISSOR_TEST);
+    glViewport(savedViewport[0], savedViewport[1], savedViewport[2], savedViewport[3]);
+    glMatrixMode(savedMatrixMode);
+}
+
+// =========================================================================
 // Playback control
 // =========================================================================
-void MC2Movie::restart() {
+void MP4Player::restart() {
     if (!fmtCtx || !vidCtx) return;
 
     playing = true;
+    paused = false;
     demuxEof = false;
     audioStarted = false;
     clockRunning = false;
@@ -435,6 +554,7 @@ void MC2Movie::restart() {
     if (vidCtx) avcodec_flush_buffers(vidCtx);
     if (audCtx) avcodec_flush_buffers(audCtx);
 
+    // Clear queues
     while (!vidPktQueue.empty()) {
         av_packet_unref(vidPktQueue.front());
         av_packet_free(&vidPktQueue.front());
@@ -448,26 +568,42 @@ void MC2Movie::restart() {
         }
     }
 
+    // Audio stays paused until primed in update()
     if (audioDevice) SDL_PauseAudioDevice(audioDevice, 1);
 }
 
-void MC2Movie::stop() {
+void MP4Player::stop() {
     playing = false;
+    paused = false;
     if (audioDevice) SDL_PauseAudioDevice(audioDevice, 1);
 }
 
-bool MC2Movie::isPlaying() const {
-    return playing;
+void MP4Player::pause() {
+    if (!playing) return;
+    paused = !paused;
+    if (audioDevice) SDL_PauseAudioDevice(audioDevice, paused ? 1 : 0);
 }
 
-void MC2Movie::setRect(RECT rect) {
+bool MP4Player::isPlaying() {
+    return playing && !paused;
+}
+
+bool MP4Player::isDone() {
+    return !playing;
+}
+
+void MP4Player::setVolume(float volume) {
+    // SDL2 doesn't have per-device volume; would need to scale in callback
+}
+
+void MP4Player::setRect(RECT rect) {
     displayRect = rect;
 }
 
-const std::string& MC2Movie::getMovieName() const {
+std::string MP4Player::getMovieName() const {
     return moviePath;
 }
 
-DWORD MC2Movie::getTextureHandle() const {
-    return gosTextureHandle;
+int MP4Player::getFrameCount() const {
+    return frameCount;
 }

--- a/code/mp4player.h
+++ b/code/mp4player.h
@@ -1,18 +1,15 @@
-#ifndef MC2MOVIE_H
-#define MC2MOVIE_H
+#ifndef MP4PLAYER_H
+#define MP4PLAYER_H
 
-// MC2Movie — Video playback decoded by FFmpeg into a gos-owned texture.
-// Decode/audio machinery cloned from MP4Player; rendering is done by the
-// caller via the standard gos UI pipeline (gos_SetRenderState +
-// gos_DrawQuads against getTextureHandle()).
-//
-// See FMV_DESIGN.md §2 for the public API and §4 for texture lifecycle.
+// MP4Player — Video playback using separate packet queues (ffplay/VLC architecture)
+// Audio callback is master clock. Video decoded on demand, PTS-gated.
 
 #include <string>
 #include <queue>
 #include <mutex>
 #include <atomic>
 #include <SDL2/SDL.h>
+#include <GL/glew.h>
 #include <windows.h>
 
 extern "C" {
@@ -24,25 +21,32 @@ extern "C" {
 #include <libavutil/opt.h>
 }
 
-class MC2Movie {
+class MP4Player {
 public:
-    MC2Movie();
-    ~MC2Movie();
+    MP4Player(const std::string& moviePath, SDL_Window* window, SDL_GLContext context);
+    ~MP4Player();
 
-    bool init(const char* path, RECT rect, bool loop);
-    void update();
-    bool isPlaying() const;
+    void init(const char* path, RECT rect, bool looped, SDL_Window* window, SDL_GLContext context);
+    void update();   // demux + decode audio + decode video (one frame)
+    void render();   // draw current frame to displayRect
     void stop();
+    void pause();
     void restart();
-    const std::string& getMovieName() const;
+    bool isPlaying();
+    bool isDone();
+    void setVolume(float volume);
     void setRect(RECT rect);
-    DWORD getTextureHandle() const;
+    std::string getMovieName() const;
+    int getFrameCount() const;
+
+    double frameRate;
 
 private:
     void openFile(const std::string& path);
     void cleanup();
-    void demux();
-    void decodeVideo();
+    void demux();            // read packets, route to queues
+    void decodeVideo();      // pop video packets, decode until next frame ready
+    void initTexture();
 
     static void audioCallback(void* userdata, Uint8* stream, int len);
     double getClock();
@@ -61,7 +65,6 @@ private:
     double vidTimeBase, audTimeBase;
     double frameDur;
     int vidW, vidH;
-    double frameRate;
 
     // Video packet queue
     std::queue<AVPacket*> vidPktQueue;
@@ -85,9 +88,11 @@ private:
     bool hasAudio;
     bool audioStarted;
 
-    // gos-owned frame texture (replaces MP4Player's private GLuint).
-    DWORD gosTextureHandle;
+    // GL rendering
+    GLuint textureID;
     bool textureReady;
+    SDL_Window* sdlWindow;
+    SDL_GLContext glContext;
 
     // Pending video frame (decoded, waiting for PTS)
     uint8_t* pendingData;
@@ -98,6 +103,7 @@ private:
     RECT displayRect;
     std::string moviePath;
     bool playing;
+    bool paused;
     bool looped;
     bool demuxEof;
     bool clockRunning;


### PR DESCRIPTION
Closes #22.

cc @Methuselas — thanks for the back-and-forth on the issue.

## Summary

The Bink codec that shipped with MC2 no longer works on modern Windows, and the `MC2Movie` path in the tree was the original Microsoft stub that never played anything standalone. This PR replaces it with an FFmpeg decode pipeline so the game's FMVs play on any current system, using `.mp4` source assets.

Two video classes cohabit, sharing a decode/audio core but differing in texture ownership:

- **`MC2Movie`** (`code/mc2movie.{h,cpp}`) — decodes FFmpeg, uploads into a gos-owned texture via `glTexSubImage2D`. Used at mission selection and for in-mission cinematics; callers draw via `gos_DrawQuads`.
- **`MP4Player`** (`code/mp4player.{h,cpp}`) — decodes FFmpeg, uploads into its own GL texture, renders with its own viewport/scissor and state save+restore. Used for intro, credits, pilot portraits, and full-screen cinematics.

Both are audio-master-clock with wall-clock fallback and PTS-gated video. Separate packet queues for audio and video (ffplay/VLC style) keep them decoupled.

## What's in the PR

- FFmpeg dependency in `CMakeLists.txt` (`avcodec`, `avformat`, `avutil`, `swscale`, `swresample`).
- The two video classes above plus `code/clean_mp4_player.cpp` — a standalone reference player target, useful for isolating decode bugs before attributing them to game integration.
- A new `gos_GetTextureGLId()` in GameOS that returns the underlying GL id for a gos texture — lets video code upload via `glTexSubImage2D` directly without `gos_LockTexture`'s readback + byte-swap overhead.
- Integration at every FMV callsite: main menu intro, mission selection, briefing screens, in-mission cinematics, pilot portraits, full-screen cinematics, credits.
- Two discrete bug fixes required to make pilot-portrait clips run clean:
  - `sws_scale` SIMD tail overrun on SIMD-unfriendly widths (the 76-wide pilot-portrait clips) — tail-guarded the destination buffer.
  - `ForceGroupIcon::bMovie` use-after-free — demoted a shared static to per-instance with a clearly-owned lifecycle.

Commit message has the full technical narrative for both fixes.

## Testing

Verified end-to-end on a clean retail MC2 install on Windows 11 64-bit: MSFT intro, CINEMA1–5, pre-mission briefings, in-mission cinematics, pilot acknowledgment videos. No crashes, no heap corruption, audio in sync.

## What's not in the PR

Kept this strictly to the FMV pipeline. A few adjacent QoL improvements from my fork (stdout logging to a file for bug reports, OS cursor hide, etc.) are not included — happy to open follow-ups for any of those if you're interested.

## Dependency note

FFmpeg is a new runtime dependency (5 DLLs). I pull headers and libs from `3rdparty/ffmpeg/` relative to the source root, matching the existing `3rdparty/` layout. If you'd prefer a different lookup strategy (system package, `pkg-config`, etc.) happy to adjust.

Thanks for maintaining the project.