### PR TITLE
fix: skip built-in campaigns in FindFirstFile scan to avoid duplicates

### DIFF
--- a/code/logisticsdialog.cpp
+++ b/code/logisticsdialog.cpp
@@ -526,8 +526,6 @@ void LogisticsSaveDialog::initDialog( const char* path, bool bCampaign )
 		{
 			if ((findResult.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) == 0)
 			{
-				aLocalizedListItem* pEntry = new aLocalizedListItem();
-				*pEntry = s_instance->templateItem;
 				char* pExt = strstr( findResult.cFileName, ".fit" );
 				if ( !pExt  )
 				{
@@ -535,7 +533,22 @@ void LogisticsSaveDialog::initDialog( const char* path, bool bCampaign )
 				}
 				if ( pExt )
 					*pExt = '\0';
-			
+
+				// Skip the two built-in campaigns here — they are handled by
+				// the fileExists() defensive-add block below, which works
+				// whether they are loose on disk or packed inside a fastfile.
+				// Without this skip, loose-file builds list both entries
+				// twice.
+				if ( bCampaign &&
+					 (S_stricmp( findResult.cFileName, "campaign" ) == 0 ||
+					  S_stricmp( findResult.cFileName, "tutorial" ) == 0) )
+				{
+					continue;
+				}
+
+				aLocalizedListItem* pEntry = new aLocalizedListItem();
+				*pEntry = s_instance->templateItem;
+
 				if (!bCampaign && isCorrectVersionSaveGame(findResult.cFileName))
 					pEntry->setText( findResult.cFileName );
 				else if (bCampaign)


### PR DESCRIPTION
Closes #27.

## Summary

`LogisticsSaveDialog::initDialog()` in `code/logisticsdialog.cpp` adds campaign list entries in two phases:

1. **Scan phase** — walks `campaignPath/*.fit` with `FindFirstFile`.
2. **Defensive-add phase** — explicitly adds `campaign.fit` and `tutorial.fit` via `fileExists()` as a fallback for retail installs where those files live inside `.fst` fastfiles (invisible to `FindFirstFile`).

On any build where the two campaign files are loose on disk — most from-source setups, plus forks that ship campaigns unpacked — both phases run and each entry duplicates in the **New Campaign** listbox.

## Fix

Skip `campaign` and `tutorial` during the `FindFirstFile` scan when `bCampaign` is set. The defensive-add block already handles those two names correctly for both loose and fastfile-packed installs, so dropping them from the scan is the minimal change that eliminates duplication without regressing the retail path. Save-game browsing (`bCampaign == false`) is unaffected.

Used the codebase's existing `S_stricmp` platform-abstracted comparison rather than `_stricmp` so this stays cross-platform (Linux builds compile the same block).

## Testing

Verified on a loose-file build (Windows 11 64-bit):
- Before: listbox shows 4 entries — *Carver V*, *Tutorial*, *Carver V*, *Tutorial*.
- After: listbox shows 2 entries — *Carver V*, *Tutorial*.

Both entries start correctly when clicked.

Have not tested the retail fastfile-packed path myself (don't currently have one handy), but the fix only removes entries from the scan; the defensive-add block below is unchanged, so retail behavior should be identical to before.