### PR TITLE
Fix invisible compass HUD by disabling alpha test in compass pass

### DIFF
--- a/mclib/txmmgr.cpp
+++ b/mclib/txmmgr.cpp
@@ -1067,7 +1067,7 @@ void MC_TextureManager::renderLists (void)
 			else if (totalVertices > MAX_SENDDOWN)
 			{
 				gos_SetRenderState( gos_State_Texture, masterTextureNodes[masterVertexNodes[i].textureIndex].get_gosTextureHandle());
-				
+
 				//Must divide up vertices into batches of 10,000 each to send down.
 				// Somewhere around 20000 to 30000 it really gets screwy!!!
 				long currentVertices = 0;
@@ -1077,9 +1077,9 @@ void MC_TextureManager::renderLists (void)
 					long tVertices = totalVertices - currentVertices;
 					if (tVertices > MAX_SENDDOWN)
 						tVertices = MAX_SENDDOWN;
-					
+
 					gos_RenderIndexedArray(v, tVertices, indexArray, tVertices );
-					
+
 					currentVertices += tVertices;
 				}
 			}
@@ -1089,7 +1089,8 @@ void MC_TextureManager::renderLists (void)
 			masterVertexNodes[i].currentVertex = masterVertexNodes[i].vertices;
 		}
 	}
-	
+
+
 	if (Environment.Renderer == 3)
 	{
 		//Do NOT draw the water as transparent in software
@@ -1571,8 +1572,17 @@ void MC_TextureManager::renderLists (void)
 	gos_SetRenderState( gos_State_ZCompare, 0);
 	gos_SetRenderState( gos_State_Perspective, 1);
  	gos_SetRenderState( gos_State_AlphaMode, gos_Alpha_AlphaInvAlpha);
-	gos_SetRenderState( gos_State_AlphaTest, 1);
-	
+	// AlphaTest must stay OFF here. The ALPHA_TEST variant of
+	// shaders/gos_tex_vertex.frag discards fragments where
+	// tex_color.a < 0.5, which kills every semi-transparent compass
+	// pixel (the compass HUD texture has soft-alpha edges). With
+	// AlphaMode=AlphaInvAlpha above, normal alpha blending handles
+	// the transparent background correctly — no discard needed.
+	// MS's D3D8 original tolerated AlphaTest=1 here because its
+	// fixed-function reference threshold differed; our OpenGL port's
+	// 0.5 threshold doesn't.
+	gos_SetRenderState( gos_State_AlphaTest, 0);
+
  	for (int i=0;i<nextAvailableVertexNode;i++)
 	{
 		if ((masterVertexNodes[i].flags & MC2_ISCOMPASS) &&
@@ -1583,7 +1593,7 @@ void MC_TextureManager::renderLists (void)
 			{
 				totalVertices = masterVertexNodes[i].currentVertex - masterVertexNodes[i].vertices;
 			}
-			
+
 			if (totalVertices && (totalVertices < MAX_SENDDOWN))
 			{
 				gos_SetRenderState( gos_State_Texture, masterTextureNodes[masterVertexNodes[i].textureIndex].get_gosTextureHandle());
@@ -1592,7 +1602,7 @@ void MC_TextureManager::renderLists (void)
 			else if (totalVertices > MAX_SENDDOWN)
 			{
 				gos_SetRenderState( gos_State_Texture, masterTextureNodes[masterVertexNodes[i].textureIndex].get_gosTextureHandle());
-				
+
 				//Must divide up vertices into batches of 10,000 each to send down.
 				// Somewhere around 20000 to 30000 it really gets screwy!!!
 				long currentVertices = 0;
@@ -1602,19 +1612,19 @@ void MC_TextureManager::renderLists (void)
 					long tVertices = totalVertices - currentVertices;
 					if (tVertices > MAX_SENDDOWN)
 						tVertices = MAX_SENDDOWN;
-					
+
 					gos_RenderIndexedArray(v, tVertices, indexArray, tVertices );
-					
+
 					currentVertices += tVertices;
 				}
 			}
-	
+
 			//Reset the list to zero length to avoid drawing more then once!
 			//Also comes in handy if gameLogic is not called.
 			masterVertexNodes[i].currentVertex = masterVertexNodes[i].vertices;
 		}
 	}
-	
+
 	gos_SetRenderState( gos_State_Filter, gos_FilterNone);
 	
  	for (int i=0;i<nextAvailableVertexNode;i++)


### PR DESCRIPTION
Closes #30.

## Summary

The in-game compass HUD doesn't render on this OpenGL port. Root cause is a hard-coded 0.5 alpha-test threshold in the basic vertex fragment shader that discards every semi-transparent compass pixel.

## Root cause

The dedicated compass pass at `mclib/txmmgr.cpp` sets `gos_State_AlphaTest = 1`, which selects the `ALPHA_TEST` variant of `shaders/gos_tex_vertex.frag`:

```glsl
#ifdef ALPHA_TEST
    if(tex_color.a < 0.5)
        discard;
#endif
```

The compass HUD texture has soft-alpha edges (anti-aliased). Every fragment with sampled alpha < 0.5 gets discarded, which in practice kills the entire visible compass. `gos_Alpha_AlphaInvAlpha` is already set on the line above, so normal alpha blending handles the transparent background correctly — the discard is redundant with blending and destructive for this texture.

The MS 2001 D3D8 original tolerated `AlphaTest = 1` here because its fixed-function reference threshold differed from the shader's hard-coded 0.5.

## Fix

One-line change in `mclib/txmmgr.cpp`: flip `gos_State_AlphaTest` from 1 to 0 in the compass pass only. Other passes are unaffected. Pinned with a comment explaining the invariant so it doesn't get re-enabled.

## Test plan

- [x] Build `mc2` target clean (Release, VS 2022, x64)
- [x] Launch full_game/mc2.exe
- [x] Start a mission
- [x] Compass visible and functional (pointer rotates with camera)
- [x] Compass toggle (Ctrl+C) works both ways
- [x] No visual regressions elsewhere (sky, terrain, mechs, HUD, FX, pilot-portrait videos, in-mission cinematics all verified)

## Notes

- The soft-alpha compass behaves identically to how it looked on retail.
- Fragment blending already handles transparent pixels correctly via `gos_Alpha_AlphaInvAlpha`.
- No shader changes — the `ALPHA_TEST` shader variant remains available for any pass that genuinely wants it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)