### PR TITLE
Port retail .d3f font loader + visual-bounds API for centered widgets

### DIFF
--- a/GameOS/gameos/gameos_graphics.cpp
+++ b/GameOS/gameos/gameos_graphics.cpp
@@ -2,6 +2,7 @@
 #include <map>
 #include <algorithm>
 #include <string>
+#include <climits>
 
 #include "gameos.hpp"
 #include "font3d.hpp"
@@ -937,6 +938,7 @@ class gosFont {
         void getCharUV(int c, uint32_t* u, uint32_t* v) const;
         int getCharAdvance(int c) const;
         const gosGlyphMetrics& getGlyphMetrics(int c) const;
+        const gosGlyphInfo& getGlyphInfo() const { return gi_; }
 
 
         DWORD getTextureId() const { return tex_id_; }
@@ -2198,6 +2200,9 @@ gosFont::~gosFont()
         getGosRenderer()->deleteTexture(tex_id_);
 
     delete[] gi_.glyphs_;
+    delete[] gi_.ink_top_;
+    delete[] gi_.ink_bot_;
+    delete[] gi_.ink_valid_;
     delete[] font_name_;
     delete[] font_id_;
 }
@@ -2728,6 +2733,101 @@ void __stdcall gos_TextStringLength( DWORD* Width, DWORD* Height, const char *fm
 
     *Width = max_width;
     *Height = (num_newlines + 1) * font->getMaxCharHeight();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Visual ink bounds for the active font + text. Width matches
+// gos_TextStringLength (max line width across \n). Top/Bottom are signed
+// pixel offsets from the gos_TextSetPosition y coordinate to the topmost
+// / bottommost inked pixel that would render — independent of line_skip
+// padding. Use for vertically centering labels in fixed frames where
+// line-skip-based centering biases ALL CAPS text low.
+//
+// Negative Top is legitimate for extended glyphs (Ä Ö Ü etc.) that sit
+// above the ASCII-trimmed band — those would render slightly clipped at
+// the top under the current renderer, but the bounds still reflect
+// where ink would conceptually appear.
+//
+// Multi-line: Top is the first line's top, Bottom is
+// (num_lines − 1) * font_line_skip + last line's bottom. Single-line
+// callers (buttons / list items) get the obvious answer.
+//
+// Legacy .glyph fonts (no per-glyph ink data) fall back to
+// Top=0, Bottom=line-skip-equivalent — centering math degrades to the
+// existing line-skip-based behavior, no improvement but no regression.
+void __stdcall gos_TextVisualBounds( DWORD* Width, int* Top, int* Bottom, const char *fmt, ... )
+{
+    gosASSERT(Width && Top && Bottom);
+
+    const int   MAX_TEXT_LEN = 4096;
+    char        text[MAX_TEXT_LEN] = {0};
+    va_list     ap;
+
+    va_start(ap, fmt);
+    vsnprintf(text, MAX_TEXT_LEN - 1, fmt, ap);
+    va_end(ap);
+    text[MAX_TEXT_LEN - 1] = '\0';
+
+    const gosTextAttribs& ta = g_gos_renderer->getTextAttributes();
+    const gosFont* font = ta.FontHandle;
+    gosASSERT(font);
+
+    const gosGlyphInfo& gi = font->getGlyphInfo();
+    const int line_skip = font->getMaxCharHeight();
+
+    int max_width = 0;
+    int cur_width = 0;
+    int num_newlines = 0;
+    int first_line_top = 0;
+    int cur_line_top = INT_MAX;
+    int cur_line_bot = INT_MIN;
+    int last_inked_line_bot = INT_MIN;
+    bool first_line_inked = false;
+    bool any_ink = false;
+
+    for(const char* p = text; ; ++p) {
+        unsigned char c = (unsigned char)*p;
+        if(c == '\n' || c == '\0') {
+            if(cur_width > max_width) max_width = cur_width;
+            if(cur_line_top != INT_MAX) {
+                if(!first_line_inked) {
+                    first_line_top = cur_line_top;
+                    first_line_inked = true;
+                }
+                last_inked_line_bot = cur_line_bot;
+            }
+            if(c == '\0') break;
+            num_newlines++;
+            cur_width = 0;
+            cur_line_top = INT_MAX;
+            cur_line_bot = INT_MIN;
+            continue;
+        }
+        cur_width += font->getCharAdvance(c);
+        if(gi.ink_valid_ && c < gi.num_glyphs_ && gi.ink_valid_[c]) {
+            int t = (int)gi.ink_top_[c];
+            int b = (int)gi.ink_bot_[c];
+            if(t < cur_line_top) cur_line_top = t;
+            if(b > cur_line_bot) cur_line_bot = b;
+            any_ink = true;
+        }
+    }
+
+    *Width = (DWORD)max_width;
+
+    if(any_ink) {
+        *Top    = first_line_top;
+        *Bottom = num_newlines * line_skip + last_inked_line_bot;
+    } else if(gi.ink_valid_) {
+        // Whitespace-only or empty — degenerate, no ink to center on.
+        *Top    = 0;
+        *Bottom = 0;
+    } else {
+        // Legacy .glyph fallback — preserve line-skip-based geometry so
+        // centering math gives the same result as gos_TextStringLength.
+        *Top    = 0;
+        *Bottom = (num_newlines + 1) * line_skip;
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/GameOS/gameos/gameos_graphics.cpp
+++ b/GameOS/gameos/gameos_graphics.cpp
@@ -2274,10 +2274,17 @@ gosFont* gosFont::load(const char* fontFile) {
 
                 GLuint gl_id = gos_GetTextureGLId(tex_id);
                 glBindTexture(GL_TEXTURE_2D, gl_id);
+                // Save/restore GL_UNPACK_ALIGNMENT — it's global state
+                // and a later texture upload may rely on a different
+                // value (driver default is 4, but other code paths set
+                // it to 1 for tightly-packed sources).
+                GLint prev_unpack_alignment = 0;
+                glGetIntegerv(GL_UNPACK_ALIGNMENT, &prev_unpack_alignment);
                 glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
                 glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0,
                                 atlas.width, atlas.height,
                                 GL_RGBA, GL_UNSIGNED_BYTE, rgba);
+                glPixelStorei(GL_UNPACK_ALIGNMENT, prev_unpack_alignment);
                 glBindTexture(GL_TEXTURE_2D, 0);
                 delete[] rgba;
 
@@ -2292,7 +2299,14 @@ gosFont* gosFont::load(const char* fontFile) {
                 delete[] d3fName;
                 return font;
             }
+            // Texture allocation failed — release everything
+            // calibrate_vertical allocated, including the per-glyph ink
+            // bounds arrays, before falling through to the .bmp+.glyph
+            // path.
             delete[] gi.glyphs_;
+            delete[] gi.ink_top_;
+            delete[] gi.ink_bot_;
+            delete[] gi.ink_valid_;
             delete[] atlas.pixels;
         }
         delete[] d3fName;
@@ -2520,6 +2534,13 @@ void __stdcall gos_UnLockTexture( DWORD Handle )
 
 uint32_t __stdcall gos_GetTextureGLId( DWORD Handle )
 {
+    // gosRenderer::getTexture asserts on INVALID_TEXTURE_ID and
+    // out-of-range handles; in release builds gosASSERT is a no-op so
+    // the out-of-range case is UB. Pre-validate the obvious invalid
+    // cases so the documented "returns 0 for invalid handle" contract
+    // holds for callers that may probe with a sentinel.
+    if(!g_gos_renderer || Handle == INVALID_TEXTURE_ID)
+        return 0;
     gosTexture* tex = g_gos_renderer->getTexture( Handle );
     return tex ? tex->getTextureId() : 0;
 }
@@ -2777,38 +2798,32 @@ void __stdcall gos_TextVisualBounds( DWORD* Width, int* Top, int* Bottom, const 
 
     int max_width = 0;
     int cur_width = 0;
-    int num_newlines = 0;
-    int first_line_top = 0;
-    int cur_line_top = INT_MAX;
-    int cur_line_bot = INT_MIN;
-    int last_inked_line_bot = INT_MIN;
-    bool first_line_inked = false;
+    int line_index = 0;
+    int min_top = INT_MAX;
+    int max_bot = INT_MIN;
     bool any_ink = false;
 
+    // Per-glyph: project each ink position into the multi-line block's
+    // y coordinate as `line_index * line_skip + ink_offset`. Tracking
+    // min/max globally avoids a leading-empty-lines bug where
+    // first-line-ink bookkeeping would otherwise emit a Top that
+    // ignores the line offset.
     for(const char* p = text; ; ++p) {
         unsigned char c = (unsigned char)*p;
         if(c == '\n' || c == '\0') {
             if(cur_width > max_width) max_width = cur_width;
-            if(cur_line_top != INT_MAX) {
-                if(!first_line_inked) {
-                    first_line_top = cur_line_top;
-                    first_line_inked = true;
-                }
-                last_inked_line_bot = cur_line_bot;
-            }
             if(c == '\0') break;
-            num_newlines++;
+            line_index++;
             cur_width = 0;
-            cur_line_top = INT_MAX;
-            cur_line_bot = INT_MIN;
             continue;
         }
         cur_width += font->getCharAdvance(c);
         if(gi.ink_valid_ && c < gi.num_glyphs_ && gi.ink_valid_[c]) {
-            int t = (int)gi.ink_top_[c];
-            int b = (int)gi.ink_bot_[c];
-            if(t < cur_line_top) cur_line_top = t;
-            if(b > cur_line_bot) cur_line_bot = b;
+            int base = line_index * line_skip;
+            int t = base + (int)gi.ink_top_[c];
+            int b = base + (int)gi.ink_bot_[c];
+            if(t < min_top) min_top = t;
+            if(b > max_bot) max_bot = b;
             any_ink = true;
         }
     }
@@ -2816,17 +2831,19 @@ void __stdcall gos_TextVisualBounds( DWORD* Width, int* Top, int* Bottom, const 
     *Width = (DWORD)max_width;
 
     if(any_ink) {
-        *Top    = first_line_top;
-        *Bottom = num_newlines * line_skip + last_inked_line_bot;
+        *Top    = min_top;
+        *Bottom = max_bot;
     } else if(gi.ink_valid_) {
         // Whitespace-only or empty — degenerate, no ink to center on.
         *Top    = 0;
         *Bottom = 0;
     } else {
-        // Legacy .glyph fallback — preserve line-skip-based geometry so
-        // centering math gives the same result as gos_TextStringLength.
+        // Legacy .glyph fallback — line-skip-based geometry under the
+        // inclusive-bounds convention callers use ((Top+Bottom+1)/2).
+        // The `- 1` makes (0 + (lines*ls - 1) + 1)/2 = lines*ls/2,
+        // matching gos_TextStringLength's height/2 centering result.
         *Top    = 0;
-        *Bottom = (num_newlines + 1) * line_skip;
+        *Bottom = (line_index + 1) * line_skip - 1;
     }
 }
 

--- a/GameOS/gameos/gameos_graphics.cpp
+++ b/GameOS/gameos/gameos_graphics.cpp
@@ -2077,14 +2077,29 @@ void gosRenderer::drawText(const char* text) {
 
             const char c = text[i + pos];
 
+            // Skip non-printable control chars. findTextBreak still
+            // includes the trailing '\n' in num_chars to drive line
+            // advance via `y += font_height` below; we just must not
+            // emit a quad for it. Legacy .glyph files had a zero-width
+            // entry at index 10, so the old path drew nothing visible;
+            // D3F atlases ship a placeholder glyph there that would
+            // appear as a square at end-of-line and on \n\n blank lines.
+            if((unsigned char)c < 0x20) {
+                continue;
+            }
+
             const gosGlyphMetrics& gm = font->getGlyphMetrics(c);
             int char_off_x = gm.minx;
             int char_off_y = font_ascent - gm.maxy;
             int char_w = gm.maxx - gm.minx;
             int char_h = gm.maxy - gm.miny;
 
-            uint32_t iu0 = gm.u + char_off_x;
-            uint32_t iv0 = gm.v + char_off_y;
+            // u/v are the actual atlas sample origin under the post-load
+            // contract — char_off_x/y drive screen quad position only,
+            // not the atlas read. The legacy .glyph loader pre-folds its
+            // metrics so this path stays pixel-identical for that format.
+            uint32_t iu0 = gm.u;
+            uint32_t iv0 = gm.v;
             uint32_t iu1 = iu0 + char_w;
             uint32_t iv1 = iv0 + char_h;
 
@@ -2100,14 +2115,18 @@ void gosRenderer::drawText(const char* text) {
         y += font_height;
         pos += num_chars;
     }
-    // FIXME: save states before messing with it, because user code can set its ow and does not know that something was changed by us
-    
+    // Save Texture/Filter/TextureAddress so the text draw doesn't leak
+    // state to whatever the next caller relies on. Filter was being
+    // leaked previously (only Texture was saved); TextureAddress is now
+    // forced to clamp because the default wrap mode samples adjacent
+    // glyphs at atlas edges with nearest filtering.
     int prev_texture = getRenderState(gos_State_Texture);
-    
-    // All states are set by client code
-    // so we only set font texture
+    int prev_filter  = getRenderState(gos_State_Filter);
+    int prev_addr    = getRenderState(gos_State_TextureAddress);
+
     setRenderState(gos_State_Texture, tex_id);
     setRenderState(gos_State_Filter, gos_FilterNone);
+    setRenderState(gos_State_TextureAddress, gos_TextureClamp);
 
     // for now draw anyway because no render state saved for draw calls
     applyRenderStates();
@@ -2121,8 +2140,8 @@ void gosRenderer::drawText(const char* text) {
     fg.w = 255.0f;//(ta.Foreground & 0xFF000000) >> 24;
     fg = fg / 255.0f;
     mat->getShader()->setFloat4(s_Foreground, fg);
-    //ta.Size 
-    //ta.WordWrap 
+    //ta.Size
+    //ta.WordWrap
     //ta.Proportional
     //ta.Bold
     //ta.Italic
@@ -2135,6 +2154,8 @@ void gosRenderer::drawText(const char* text) {
     text_->rewind();
 
     setRenderState(gos_State_Texture, prev_texture);
+    setRenderState(gos_State_Filter, prev_filter);
+    setRenderState(gos_State_TextureAddress, prev_addr);
 
     afterDrawCall();
 }
@@ -2187,9 +2208,94 @@ gosFont* gosFont::load(const char* fontFile) {
     char fname[256];
     char dir[256];
     _splitpath(fontFile, NULL, dir, fname, NULL);
+
+    // Retail .d3f wins when present. .bmp + .glyph stays as the
+    // permanent fallback for converted fonts and community content.
+    {
+        const char* d3f_ext = ".d3f";
+        const size_t d3fNameSize = strlen(fname) + 1 + strlen(dir) + strlen(d3f_ext) + 1;
+        char* d3fName = new char[d3fNameSize];
+        memset(d3fName, 0, d3fNameSize);
+        uint32_t d3f_len = S_snprintf(d3fName, d3fNameSize, "%s/%s%s", dir, fname, d3f_ext);
+        gosASSERT(d3f_len <= d3fNameSize - 1);
+
+        gosGlyphInfo gi;
+        gosD3FAtlas atlas;
+        if(gos_load_d3f(d3fName, gi, atlas)) {
+            // Legacy .glyph sidecar bridge — when a same-basename
+            // .glyph exists alongside the .d3f, adopt its line spacing
+            // and max-advance globals. UI widgets were authored against
+            // those values; D3F's dwFontHeight em-box would pack lines
+            // ~2x denser than retail. font_ascent_ is intentionally
+            // left at the calibrated value (visible band height) so
+            // the per-glyph maxy/miny set by calibrate_vertical stay
+            // consistent with the renderer's char_off_y math.
+            //
+            // .glyph header layout (matches gos_load_glyphs):
+            //   u32 num_glyphs, start_glyph, max_advance, ascent, line_skip
+            {
+                const char* glyph_ext = ".glyph";
+                const size_t sidecarNameSize = strlen(fname) + 1 + strlen(dir) + strlen(glyph_ext) + 1;
+                char* sidecarName = new char[sidecarNameSize];
+                memset(sidecarName, 0, sidecarNameSize);
+                S_snprintf(sidecarName, sidecarNameSize, "%s/%s%s", dir, fname, glyph_ext);
+
+                FILE* sidecar = fopen(sidecarName, "rb");
+                if(sidecar) {
+                    uint32_t legacy_globals[5] = {0};
+                    if(fread(legacy_globals, sizeof(uint32_t), 5, sidecar) == 5) {
+                        gi.max_advance_    = legacy_globals[2];
+                        gi.font_line_skip_ = legacy_globals[4];
+                    }
+                    fclose(sidecar);
+                }
+                delete[] sidecarName;
+            }
+
+            DWORD tex_id = gos_NewEmptyTexture(gos_Texture_Alpha, d3fName,
+                                               RECT_TEX(atlas.width, atlas.height), 0);
+            if(tex_id != 0) {
+                // Expand 8-bit alpha to RGBA8: fan alpha into R for the
+                // gos_text shader's .xxxx sample. Other channels also
+                // populated so any future shader change still gets sane data.
+                const size_t pixel_count = (size_t)atlas.width * (size_t)atlas.height;
+                DWORD* rgba = new DWORD[pixel_count];
+                for(size_t i = 0; i < pixel_count; ++i) {
+                    uint32_t a = atlas.pixels[i];
+                    rgba[i] = (a) | (a << 8) | (a << 16) | (a << 24);
+                }
+                delete[] atlas.pixels;
+                atlas.pixels = NULL;
+
+                GLuint gl_id = gos_GetTextureGLId(tex_id);
+                glBindTexture(GL_TEXTURE_2D, gl_id);
+                glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
+                glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0,
+                                atlas.width, atlas.height,
+                                GL_RGBA, GL_UNSIGNED_BYTE, rgba);
+                glBindTexture(GL_TEXTURE_2D, 0);
+                delete[] rgba;
+
+                gosFont* font = new gosFont();
+                font->gi_ = gi;
+                font->font_name_ = new char[strlen(fname) + 1];
+                strcpy(font->font_name_, fname);
+                font->font_id_ = new char[strlen(fontFile) + 1];
+                strcpy(font->font_id_, fontFile);
+                font->tex_id_ = tex_id;
+
+                delete[] d3fName;
+                return font;
+            }
+            delete[] gi.glyphs_;
+            delete[] atlas.pixels;
+        }
+        delete[] d3fName;
+    }
+
     const char* tex_ext = ".bmp";
     const char* glyph_ext = ".glyph";
-    
+
 	const size_t textureNameSize = strlen(fname) + sizeof('/') + strlen(dir) + strlen(tex_ext) + 1;
     char* textureName = new char[textureNameSize];
 	memset(textureName, 0, textureNameSize);
@@ -2405,6 +2511,12 @@ void __stdcall gos_UnLockTexture( DWORD Handle )
     ptex->Unlock();
 
     //gosASSERT(0 && "Not implemented");
+}
+
+uint32_t __stdcall gos_GetTextureGLId( DWORD Handle )
+{
+    gosTexture* tex = g_gos_renderer->getTexture( Handle );
+    return tex ? tex->getTextureId() : 0;
 }
 
 void __stdcall gos_PushRenderStates()

--- a/GameOS/gameos/gos_font.cpp
+++ b/GameOS/gameos/gos_font.cpp
@@ -3,6 +3,7 @@
 // errno + strerror
 #include <errno.h>
 #include <string.h>
+#include <stdlib.h>
 
 #include "gameos.hpp"
 #include "gos_font.h"
@@ -28,15 +29,360 @@ bool gos_load_glyphs(const char* glyphFile, gosGlyphInfo& gi)
     gi.glyphs_ = new gosGlyphMetrics[gi.num_glyphs_];
 
     while(num_structs_read!= gi.num_glyphs_) {
-        num_structs_read+= fread(&gi.glyphs_[num_structs_read], 
-                sizeof(gosGlyphMetrics), 
+        num_structs_read+= fread(&gi.glyphs_[num_structs_read],
+                sizeof(gosGlyphMetrics),
                 gi.num_glyphs_ - num_structs_read,
                 glyph_info);
     }
 
     fclose(glyph_info);
 
+    // Pre-fold legacy metrics into the renderer's "u/v = actual sample
+    // origin" contract. The on-disk .glyph format stores u/v as a cell
+    // origin and minx / (font_ascent - maxy) as both screen offset and
+    // atlas shift. The renderer no longer adds those into the UV; do
+    // the shift here so the legacy path renders pixel-identical.
+    //
+    // Guards underflow into uint32 u/v with a SPEW so a malformed
+    // community .glyph that violates the assumption is visible in the
+    // log rather than silently sampling atlas col 0.
+    for(uint32_t i = 0; i < gi.num_glyphs_; ++i) {
+        gosGlyphMetrics& g = gi.glyphs_[i];
+        int32_t shifted_u = (int32_t)g.u + g.minx;
+        int32_t shifted_v = (int32_t)g.v + ((int32_t)gi.font_ascent_ - g.maxy);
+        if(shifted_u < 0 || shifted_v < 0) {
+            SPEW(("glyph pre-fold underflow in %s at idx %u "
+                  "(u=%u minx=%d v=%u maxy=%d ascent=%u); clamping to 0\n",
+                  glyphFile, i, g.u, g.minx, g.v, g.maxy, gi.font_ascent_));
+            if(shifted_u < 0) shifted_u = 0;
+            if(shifted_v < 0) shifted_v = 0;
+        }
+        g.u = (uint32_t)shifted_u;
+        g.v = (uint32_t)shifted_v;
+    }
+
     return true;
 }
 
 
+// ----------------------------------------------------------------------------
+// .d3f loader (retail FontEdit format)
+//
+// Two on-disk versions coexist:
+//   v1 ("D3DF", 0x46443344) — D3DFontData with embedded RGBA-ish pixels
+//   v4 ("D3F4", 0x34463344) — D3DFontData1 with iTextureCount inline
+//                             D3DFontTexture blobs
+// Both atlases are 8-bit alpha. v4 stores side length per blob (square);
+// v1 stores rectangular dwWidth/dwHeight. See devlogs/fonts_d3f_loader_2026-04-25.md
+// for the format details and the empirical sig values (the shipped header
+// at GameOS/include/font3d.hpp only documents v1).
+// ----------------------------------------------------------------------------
+
+namespace {
+
+const uint32_t D3F_SIG_V1 = 0x46443344u; // "D3DF"
+const uint32_t D3F_SIG_V4 = 0x34463344u; // "D3F4"
+
+const uint32_t D3F_MAX_ATLAS_DIM = 4096;
+
+// Field-by-field readers. Avoid blob reads so #pragma pack(1) and bool
+// width don't cause portability surprises across MSVC / g++.
+bool read_u8 (FILE* f, uint8_t*  v) { return fread(v, 1, 1, f) == 1; }
+bool read_u32(FILE* f, uint32_t* v) { return fread(v, 4, 1, f) == 1; }
+bool read_i32(FILE* f, int32_t*  v) { return fread(v, 4, 1, f) == 1; }
+bool read_bytes(FILE* f, void* dst, size_t n) {
+    return fread(dst, 1, n, f) == n;
+}
+
+void zero_glyphs(gosGlyphInfo& gi) {
+    for(uint32_t i = 0; i < gi.num_glyphs_; ++i) {
+        gosGlyphMetrics& g = gi.glyphs_[i];
+        g.minx = g.maxx = g.miny = g.maxy = 0;
+        g.advance = 0;
+        g.valid = 0;
+        g.u = g.v = 0;
+    }
+}
+
+// Scan a glyph rect for tightest non-zero alpha rows. Returns false if the
+// rect contained no opaque pixels.
+bool scan_glyph_v_extent(const uint8_t* atlas, int atlas_w, int atlas_h,
+                         int x, int y, int w, int h,
+                         int* out_top, int* out_bot)
+{
+    if(w <= 0 || h <= 0) return false;
+    if(x < 0 || y < 0 || x + w > atlas_w || y + h > atlas_h) return false;
+    int top = -1, bot = -1;
+    for(int row = 0; row < h; ++row) {
+        const uint8_t* line = atlas + (y + row) * atlas_w + x;
+        for(int col = 0; col < w; ++col) {
+            if(line[col]) {
+                if(top < 0) top = row;
+                bot = row;
+                break;
+            }
+        }
+    }
+    if(top < 0) return false;
+    *out_top = top;
+    *out_bot = bot;
+    return true;
+}
+
+// Derive ascent / line_skip / per-glyph maxy + atlas v-shift from the
+// tightest opaque rows across all valid glyphs. D3F doesn't encode a
+// baseline, so all glyphs share the same vertical extent in the rendered
+// output — top_trim shifts the atlas sample origin so the trimmed band
+// aligns with the glyph quad height.
+//
+// Scan restricted to printable ASCII (0x20-0x7E). Rare extended-ASCII
+// slots (accented capitals like Ä Ö Ü at 0xC4/0xD6/0xDC) reach 3-5 px
+// higher than ordinary caps in the AgencyFB atlases — letting them
+// drive global_top adds permanent blank headroom to every line of UI
+// text and visibly pushes ASCII content low. Trade-off: accents on
+// extended chars may render slightly clipped, but those chars are
+// vanishingly rare in MC2's UI strings.
+void calibrate_vertical(gosGlyphInfo& gi, const gosD3FAtlas& atlas,
+                        const uint8_t* bX, const uint8_t* bY,
+                        const uint8_t* bW, uint32_t font_height)
+{
+    int global_top = (int)font_height;
+    int global_bot = -1;
+    const uint32_t scan_lo = 0x20;
+    const uint32_t scan_hi = 0x7E;
+    for(uint32_t c = scan_lo; c <= scan_hi && c < gi.num_glyphs_; ++c) {
+        if(!gi.glyphs_[c].valid) continue;
+        int top, bot;
+        if(!scan_glyph_v_extent(atlas.pixels, atlas.width, atlas.height,
+                                bX[c], bY[c], bW[c], (int)font_height,
+                                &top, &bot)) {
+            continue;
+        }
+        if(top < global_top) global_top = top;
+        if(bot > global_bot) global_bot = bot;
+    }
+
+    int top_trim = (global_bot >= 0) ? global_top : 0;
+    int visible_height = (global_bot >= 0)
+        ? (global_bot - global_top + 1)
+        : (int)font_height;
+
+    if(visible_height < 1) visible_height = 1;
+    if(visible_height > (int)font_height) visible_height = (int)font_height;
+
+    for(uint32_t c = 0; c < gi.num_glyphs_; ++c) {
+        gosGlyphMetrics& g = gi.glyphs_[c];
+        if(!g.valid) continue;
+        g.miny = 0;
+        g.maxy = visible_height;
+        g.v   += (uint32_t)top_trim;
+    }
+
+    gi.font_ascent_    = (uint32_t)visible_height;
+    gi.font_line_skip_ = (uint32_t)visible_height + 1; // +1 leading
+}
+
+bool parse_v4(FILE* f, gosGlyphInfo& gi, gosD3FAtlas& atlas)
+{
+    // sig already consumed
+    char    szFaceName[64];
+    int32_t iSize, iWeight, iTextureCount;
+    uint8_t bItalic;
+    uint32_t dwFontHeight;
+    uint8_t bTexture[256], bX[256], bY[256], bW[256];
+    int8_t  cA[256], cC[256];
+
+    if(!read_bytes(f, szFaceName, 64))   return false;
+    if(!read_i32  (f, &iSize))           return false;
+    if(!read_u8   (f, &bItalic))         return false;
+    if(!read_i32  (f, &iWeight))         return false;
+    if(!read_i32  (f, &iTextureCount))   return false;
+    if(!read_u32  (f, &dwFontHeight))    return false;
+    if(!read_bytes(f, bTexture, 256))    return false;
+    if(!read_bytes(f, bX, 256))          return false;
+    if(!read_bytes(f, bY, 256))          return false;
+    if(!read_bytes(f, bW, 256))          return false;
+    if(!read_bytes(f, cA, 256))          return false;
+    if(!read_bytes(f, cC, 256))          return false;
+
+    if(iTextureCount != 1) {
+        SPEW(("d3f v4 with iTextureCount=%d not supported (need 1)\n",
+              iTextureCount));
+        return false;
+    }
+    if(dwFontHeight == 0 || dwFontHeight > D3F_MAX_ATLAS_DIM) {
+        SPEW(("d3f v4 implausible dwFontHeight=%u\n", dwFontHeight));
+        return false;
+    }
+
+    uint32_t dwSize = 0;
+    if(!read_u32(f, &dwSize))                  return false;
+    if(dwSize == 0 || dwSize > D3F_MAX_ATLAS_DIM) {
+        SPEW(("d3f v4 implausible atlas dim=%u\n", dwSize));
+        return false;
+    }
+
+    size_t pixel_count = (size_t)dwSize * (size_t)dwSize;
+    uint8_t* pixels = new uint8_t[pixel_count];
+    if(!read_bytes(f, pixels, pixel_count)) {
+        delete[] pixels;
+        return false;
+    }
+
+    gi.num_glyphs_   = 256;
+    gi.start_glyph_  = 0;
+    gi.glyphs_       = new gosGlyphMetrics[256];
+    gi.font_ascent_  = dwFontHeight;     // overwritten by calibrate_vertical
+    gi.font_line_skip_ = dwFontHeight;   // overwritten by calibrate_vertical
+    zero_glyphs(gi);
+
+    uint32_t max_adv = 0;
+    for(int c = 0; c < 256; ++c) {
+        gosGlyphMetrics& g = gi.glyphs_[c];
+        int w   = (int)bW[c];
+        int pre = (int)cA[c];
+        int post= (int)cC[c];
+        int adv = pre + w + post;
+
+        // Under the renderer's "u/v = actual sample origin" contract,
+        // u/v point at the glyph's pixels in the atlas (bX/bY) and
+        // minx/maxx are the signed screen bearing rect.
+        g.minx    = pre;
+        g.maxx    = pre + w;
+        g.miny    = 0;
+        g.maxy    = (int32_t)dwFontHeight;
+        g.advance = adv;
+        g.u       = bX[c];
+        g.v       = bY[c];
+        g.valid   = (w > 0) ? 1 : 0;
+
+        if(g.valid && (uint32_t)adv > max_adv) max_adv = (uint32_t)adv;
+    }
+    gi.max_advance_ = max_adv ? max_adv : dwFontHeight;
+
+    atlas.pixels = pixels;
+    atlas.width  = (int)dwSize;
+    atlas.height = (int)dwSize;
+
+    calibrate_vertical(gi, atlas, bX, bY, bW, dwFontHeight);
+    return true;
+}
+
+bool parse_v1(FILE* f, gosGlyphInfo& gi, gosD3FAtlas& atlas)
+{
+    // sig already consumed
+    uint32_t dwWidth, dwFontHeight, dwHeight;
+    if(!read_u32(f, &dwWidth))        return false;
+    if(!read_u32(f, &dwFontHeight))   return false;
+    if(!read_u32(f, &dwHeight))       return false;
+
+    if(dwWidth  == 0 || dwWidth  > D3F_MAX_ATLAS_DIM ||
+       dwHeight == 0 || dwHeight > D3F_MAX_ATLAS_DIM ||
+       dwFontHeight == 0 || dwFontHeight > dwHeight)
+    {
+        SPEW(("d3f v1 implausible header w=%u h=%u fh=%u\n",
+              dwWidth, dwHeight, dwFontHeight));
+        return false;
+    }
+
+    uint32_t dwX[256], dwY[256], dwWidths[256];
+    int32_t  nA[256], nC[256];
+    if(!read_bytes(f, dwX,      sizeof(dwX)))      return false;
+    if(!read_bytes(f, dwY,      sizeof(dwY)))      return false;
+    if(!read_bytes(f, dwWidths, sizeof(dwWidths))) return false;
+    if(!read_bytes(f, nA,       sizeof(nA)))       return false;
+    if(!read_bytes(f, nC,       sizeof(nC)))       return false;
+
+    size_t pixel_count = (size_t)dwWidth * (size_t)dwHeight;
+    uint8_t* pixels = new uint8_t[pixel_count];
+    if(!read_bytes(f, pixels, pixel_count)) {
+        delete[] pixels;
+        return false;
+    }
+
+    gi.num_glyphs_   = 256;
+    gi.start_glyph_  = 0;
+    gi.glyphs_       = new gosGlyphMetrics[256];
+    gi.font_ascent_  = dwFontHeight;
+    gi.font_line_skip_ = dwFontHeight;
+    zero_glyphs(gi);
+
+    // Build a uint8 per-char width view for calibrate_vertical, which
+    // expects the v4 layout. v1 widths are uint32 — clamp to byte range
+    // since atlas dims are bounded to 4096 and per-char widths are far
+    // smaller in practice.
+    uint8_t bX[256], bY[256], bW[256];
+    uint32_t max_adv = 0;
+    for(int c = 0; c < 256; ++c) {
+        uint32_t w   = dwWidths[c];
+        int      pre = nA[c];
+        int      post= nC[c];
+        int      adv = pre + (int)w + post;
+
+        gosGlyphMetrics& g = gi.glyphs_[c];
+        g.minx    = pre;
+        g.maxx    = pre + (int32_t)w;
+        g.miny    = 0;
+        g.maxy    = (int32_t)dwFontHeight;
+        g.advance = adv;
+        g.u       = dwX[c];
+        g.v       = dwY[c];
+        g.valid   = (w > 0) ? 1 : 0;
+
+        if(g.valid && (uint32_t)adv > max_adv) max_adv = (uint32_t)adv;
+
+        bX[c] = (uint8_t)(dwX[c] & 0xFF);
+        bY[c] = (uint8_t)(dwY[c] & 0xFF);
+        bW[c] = (w > 255) ? 255 : (uint8_t)w;
+    }
+    gi.max_advance_ = max_adv ? max_adv : dwFontHeight;
+
+    atlas.pixels = pixels;
+    atlas.width  = (int)dwWidth;
+    atlas.height = (int)dwHeight;
+
+    // Calibrate using the truncated bX/bY view. Atlases over 256px on
+    // either axis would mis-locate the scan rect — guard.
+    if(dwWidth <= 256 && dwHeight <= 256) {
+        calibrate_vertical(gi, atlas, bX, bY, bW, dwFontHeight);
+    }
+    return true;
+}
+
+} // anonymous namespace
+
+bool gos_load_d3f(const char* d3fFile, gosGlyphInfo& gi, gosD3FAtlas& atlas)
+{
+    atlas.pixels = NULL;
+    atlas.width = atlas.height = 0;
+
+    FILE* f = fopen(d3fFile, "rb");
+    if(!f) return false;
+
+    uint32_t sig = 0;
+    if(!read_u32(f, &sig)) {
+        fclose(f);
+        return false;
+    }
+
+    bool ok = false;
+    if(sig == D3F_SIG_V4) {
+        ok = parse_v4(f, gi, atlas);
+    } else if(sig == D3F_SIG_V1) {
+        ok = parse_v1(f, gi, atlas);
+    } else {
+        SPEW(("d3f: unrecognized signature 0x%08x in %s\n", sig, d3fFile));
+    }
+
+    fclose(f);
+
+    if(!ok) {
+        delete[] gi.glyphs_;
+        gi.glyphs_ = NULL;
+        gi.num_glyphs_ = 0;
+        delete[] atlas.pixels;
+        atlas.pixels = NULL;
+        atlas.width = atlas.height = 0;
+    }
+    return ok;
+}

--- a/GameOS/gameos/gos_font.cpp
+++ b/GameOS/gameos/gos_font.cpp
@@ -180,6 +180,42 @@ void calibrate_vertical(gosGlyphInfo& gi, const gosD3FAtlas& atlas,
 
     gi.font_ascent_    = (uint32_t)visible_height;
     gi.font_line_skip_ = (uint32_t)visible_height + 1; // +1 leading
+
+    // Second pass: populate per-glyph ink bounds for the visual-bounds
+    // API (gos_TextVisualBounds). Scans ALL 256 slots, not just ASCII —
+    // extended glyphs need bounds too, even though they don't drive
+    // global_top/global_bot. Stored relative to the rendered quad top
+    // (post-shift), so a glyph that sat at atlas band row top_trim has
+    // ink_top=0; an extended glyph that reaches above the trim line has
+    // a negative ink_top.
+    delete[] gi.ink_top_;
+    delete[] gi.ink_bot_;
+    delete[] gi.ink_valid_;
+    gi.ink_top_   = new int8_t[gi.num_glyphs_];
+    gi.ink_bot_   = new int8_t[gi.num_glyphs_];
+    gi.ink_valid_ = new uint8_t[gi.num_glyphs_];
+    memset(gi.ink_top_,   0, gi.num_glyphs_);
+    memset(gi.ink_bot_,   0, gi.num_glyphs_);
+    memset(gi.ink_valid_, 0, gi.num_glyphs_);
+
+    for(uint32_t c = 0; c < gi.num_glyphs_; ++c) {
+        if(!gi.glyphs_[c].valid) continue;
+        int top, bot;
+        if(!scan_glyph_v_extent(atlas.pixels, atlas.width, atlas.height,
+                                bX[c], bY[c], bW[c], (int)font_height,
+                                &top, &bot)) {
+            continue;
+        }
+        int rel_top = top - top_trim;
+        int rel_bot = bot - top_trim;
+        if(rel_top < INT8_MIN) rel_top = INT8_MIN;
+        if(rel_top > INT8_MAX) rel_top = INT8_MAX;
+        if(rel_bot < INT8_MIN) rel_bot = INT8_MIN;
+        if(rel_bot > INT8_MAX) rel_bot = INT8_MAX;
+        gi.ink_top_[c]   = (int8_t)rel_top;
+        gi.ink_bot_[c]   = (int8_t)rel_bot;
+        gi.ink_valid_[c] = 1;
+    }
 }
 
 bool parse_v4(FILE* f, gosGlyphInfo& gi, gosD3FAtlas& atlas)

--- a/GameOS/gameos/gos_font.cpp
+++ b/GameOS/gameos/gos_font.cpp
@@ -28,11 +28,24 @@ bool gos_load_glyphs(const char* glyphFile, gosGlyphInfo& gi)
 
     gi.glyphs_ = new gosGlyphMetrics[gi.num_glyphs_];
 
-    while(num_structs_read!= gi.num_glyphs_) {
-        num_structs_read+= fread(&gi.glyphs_[num_structs_read],
+    while(num_structs_read != gi.num_glyphs_) {
+        size_t got = fread(&gi.glyphs_[num_structs_read],
                 sizeof(gosGlyphMetrics),
                 gi.num_glyphs_ - num_structs_read,
                 glyph_info);
+        if(got == 0) {
+            // EOF or read error — bail rather than spin forever on a
+            // truncated/corrupt .glyph file.
+            SPEW(("gos_load_glyphs: short read on %s, expected %u "
+                  "glyphs, got %u\n",
+                  glyphFile, gi.num_glyphs_, (uint32_t)num_structs_read));
+            fclose(glyph_info);
+            delete[] gi.glyphs_;
+            gi.glyphs_ = NULL;
+            gi.num_glyphs_ = 0;
+            return false;
+        }
+        num_structs_read += got;
     }
 
     fclose(glyph_info);

--- a/GameOS/gameos/gos_font.h
+++ b/GameOS/gameos/gos_font.h
@@ -22,6 +22,22 @@ struct gosGlyphInfo {
     uint32_t font_line_skip_;
 };
 
+// Atlas extracted from a .d3f file. Pixels are 8-bit alpha, square or
+// rectangular per format version. Caller takes ownership and must
+// delete[] pixels.
+struct gosD3FAtlas {
+    uint8_t* pixels;
+    int      width;
+    int      height;
+};
+
 bool gos_load_glyphs(const char* glyphFile, gosGlyphInfo& gi);
+
+// Loads a retail .d3f font (v1 or v4). On success, fills `gi` with
+// per-glyph metrics + global ascent/line_skip derived via alpha-scan,
+// and hands the embedded 8-bit alpha atlas back through `atlas`.
+// Returns false (without allocating) if the file is missing or has an
+// unrecognized signature.
+bool gos_load_d3f(const char* d3fFile, gosGlyphInfo& gi, gosD3FAtlas& atlas);
 
 #endif // GOS_FONT_H

--- a/GameOS/gameos/gos_font.h
+++ b/GameOS/gameos/gos_font.h
@@ -13,13 +13,30 @@ typedef struct {
 } gosGlyphMetrics;
 
 struct gosGlyphInfo {
-    gosGlyphInfo():num_glyphs_(0), glyphs_(0) {}
+    gosGlyphInfo()
+        : num_glyphs_(0), start_glyph_(0), glyphs_(0),
+          max_advance_(0), font_ascent_(0), font_line_skip_(0),
+          ink_top_(0), ink_bot_(0), ink_valid_(0) {}
     uint32_t num_glyphs_;
     uint32_t start_glyph_;
     gosGlyphMetrics* glyphs_;
     uint32_t max_advance_;
     uint32_t font_ascent_;
     uint32_t font_line_skip_;
+
+    // Per-glyph ink bounds, runtime-only (NOT serialized — extending
+    // gosGlyphMetrics would break gos_load_glyphs's blob-read of legacy
+    // .glyph files). Allocated only by the D3F load path; NULL for
+    // legacy .bmp+.glyph fonts. Values are int8 offsets relative to
+    // the rendered quad top (i.e. relative to atlas row top_trim, not
+    // raw atlas row 0). Negative ink_top is legitimate for extended
+    // glyphs that sit above the ASCII-trimmed band. ink_valid_[c] is
+    // 1 if the glyph has any opaque pixels, 0 otherwise (sentinel —
+    // can't use ink_top==ink_bot==0 since a real glyph may legitimately
+    // span a single row at offset 0).
+    int8_t*  ink_top_;
+    int8_t*  ink_bot_;
+    uint8_t* ink_valid_;
 };
 
 // Atlas extracted from a .d3f file. Pixels are 8-bit alpha, square or

--- a/GameOS/include/gameos.hpp
+++ b/GameOS/include/gameos.hpp
@@ -997,6 +997,21 @@ void __stdcall gos_TextDrawBackground( int Left, int Top, int Right, int Bottom,
 void __stdcall gos_TextStringLength( DWORD* Width, DWORD* Height, const char *Message, ... );
 
 //
+// Returns max line width and visual ink bounds (Top/Bottom relative to
+// gos_TextSetPosition's y coordinate). Use for vertically centering
+// labels in fixed frames where line-skip-based centering biases ALL
+// CAPS text low. Top is signed — extended glyphs (Ä Ö Ü) can sit
+// above the trimmed band.
+//
+// Multi-line: Top is the first line's top, Bottom is
+// (lines − 1) * line_skip + last line's bottom.
+//
+// Falls back to line-skip-based geometry for legacy .glyph fonts that
+// lack per-glyph ink data; centering then matches gos_TextStringLength.
+//
+void __stdcall gos_TextVisualBounds( DWORD* Width, int* Top, int* Bottom, const char *Message, ... );
+
+//
 // Draws string using current attributes and position
 //
 //  Special Codes -

--- a/GameOS/include/gameos.hpp
+++ b/GameOS/include/gameos.hpp
@@ -2842,6 +2842,14 @@ void __stdcall gos_LockTexture( DWORD Handle, DWORD MipMapSize, bool ReadOnly, T
 void __stdcall gos_UnLockTexture( DWORD Handle );
 
 //
+// Returns the underlying GL texture id for a gos texture handle, or 0
+// if the handle is invalid. Used by callers (e.g. font atlas upload)
+// that want to drive glTexSubImage2D directly against a gos-owned
+// texture without going through the lock/unlock convert path.
+//
+uint32_t __stdcall gos_GetTextureGLId( DWORD Handle );
+
+//
 // Converts from 32bpp source to subrect of n-bpp dest, bypassing intermediate 32bpp buffer
 //
 void __stdcall gos_ConvertTextureRect( DWORD Handle, DWORD DestLeft, DWORD DestTop, DWORD *Source, DWORD SourcePitch, DWORD Width, DWORD Height );

--- a/code/controlgui.cpp
+++ b/code/controlgui.cpp
@@ -1459,7 +1459,7 @@ void ControlButton::render()
 			gos_TextVisualBounds( &width, &visTop, &visBot, buffer );
 
 			data->textFont.render( buffer, location[0].x,
-				(location[0].y + location[2].y)/2 - (visTop + visBot + 1)/2 + 1,
+				(location[0].y + location[2].y)/2 - (visTop + visBot + 1)/2,
 				location[2].x - location[0].x,
 				location[2].y - location[0].y,
 				data->textColors[state], 0, 2 );

--- a/code/controlgui.cpp
+++ b/code/controlgui.cpp
@@ -1453,10 +1453,13 @@ void ControlButton::render()
 		{
 			char buffer[256];
 			cLoadString( data->textID, buffer, 256 );
-			unsigned long height = data->textFont.height();
-			
+			DWORD width;
+			int   visTop, visBot;
+			gos_TextSetAttributes( data->textFont.getTempHandle(), data->textColors[state], data->textFont.getSize(), true, true, false, false, 2 );
+			gos_TextVisualBounds( &width, &visTop, &visBot, buffer );
+
 			data->textFont.render( buffer, location[0].x,
-				(location[0].y + location[2].y)/2 - height/2 + 1,
+				(location[0].y + location[2].y)/2 - (visTop + visBot + 1)/2 + 1,
 				location[2].x - location[0].x,
 				location[2].y - location[0].y,
 				data->textColors[state], 0, 2 );

--- a/gui/abutton.cpp
+++ b/gui/abutton.cpp
@@ -159,11 +159,12 @@ void aButton::render()
 		{
 			char buffer[256];
 			cLoadString( data.textID, buffer, 256 );
-			DWORD width, height;
-			gos_TextSetAttributes(data.textFont, data.textColors[state], data.textSize, true, true, false, false, data.textAlign);			
+			DWORD width;
+			int   visTop, visBot;
+			gos_TextSetAttributes(data.textFont, data.textColors[state], data.textSize, true, true, false, false, data.textAlign);
 			gos_TextSetRegion( data.textRect.left, data.textRect.top, data.textRect.right, data.textRect.bottom );
-			gos_TextStringLength( &width, &height, buffer );
-			gos_TextSetPosition( data.textRect.left, (data.textRect.top + data.textRect.bottom)/2 - height/2 + 1 );
+			gos_TextVisualBounds( &width, &visTop, &visBot, buffer );
+			gos_TextSetPosition( data.textRect.left, (data.textRect.top + data.textRect.bottom)/2 - (visTop + visBot + 1)/2 + 1 );
 			gos_TextDraw( buffer );
 
 			if ( data.outlineText )

--- a/gui/abutton.cpp
+++ b/gui/abutton.cpp
@@ -164,7 +164,7 @@ void aButton::render()
 			gos_TextSetAttributes(data.textFont, data.textColors[state], data.textSize, true, true, false, false, data.textAlign);
 			gos_TextSetRegion( data.textRect.left, data.textRect.top, data.textRect.right, data.textRect.bottom );
 			gos_TextVisualBounds( &width, &visTop, &visBot, buffer );
-			gos_TextSetPosition( data.textRect.left, (data.textRect.top + data.textRect.bottom)/2 - (visTop + visBot + 1)/2 + 1 );
+			gos_TextSetPosition( data.textRect.left, (data.textRect.top + data.textRect.bottom)/2 - (visTop + visBot + 1)/2 );
 			gos_TextDraw( buffer );
 
 			if ( data.outlineText )

--- a/gui/alistbox.cpp
+++ b/gui/alistbox.cpp
@@ -1303,14 +1303,21 @@ void aTextListItem::render()
 	if ( y > tmpHeight && font.height( text, width() ) <= tmpHeight
 		&& !bForceToTop )
 	{
-		y = (location[2].y + location[0].y)/2.f - tmpHeight/2.f;
+		// Centered branch — use visual ink bounds so the visible text
+		// sits at true vertical center of the row, not the line-skip
+		// midpoint. Top-aligned (else) branch left untouched.
+		DWORD w;
+		int   visTop, visBot;
+		gos_TextSetAttributes( font.getTempHandle(), location[0].argb, font.getSize(), true, true, false, false, alignment );
+		gos_TextVisualBounds( &w, &visTop, &visBot, text );
+		y = (location[2].y + location[0].y)/2.f - (visTop + visBot + 1)/2.f;
 	}
 	else
 		y = location[0].y + tmpHeight/4.f;
 
 	font.render( text, location[0].x, y,
-		location[2].x - location[0].x, location[2].y - location[0].y, 
-		location[0].argb, 0, alignment ); 
+		location[2].x - location[0].x, location[2].y - location[0].y,
+		location[0].argb, 0, alignment );
 }
 
 void aTextListItem::setText( long resID )


### PR DESCRIPTION
Replaces the `.bmp`+`.glyph` fallback path as the default for menu-UI fonts, restoring retail's font geometry. Three commits, ~7 files / ~684 lines, builds clean against current `master` (verified locally on MSVC 2022 Release x64).

Supersedes #31, which was closed because it accidentally bundled unrelated work from the head fork.

## Why

The shipped `.glyph` files were produced by a converter that normalized vertical metrics and dropped lowercase glyphs from atlases like `arialnarrow8` (only uppercase + digits made it through). So menu UI rendered with mis-scaled lines, lowercase pilot/mech names were invisible, and several widgets had subtle vertical-centering bugs. Reading the original retail `.d3f` (FontEdit) files directly restores the intended geometry.

## What's in the three commits

### `e45f79d` — D3F loader with ASCII-restricted calibration + .glyph sidecar bridge

- `gos_load_d3f`: parses v1 (`D3DF`) and v4 (`D3F4`) signatures, extracts the embedded 8-bit alpha atlas, fills `gosGlyphInfo` + per-glyph metrics. Format documented inline (the shipped `font3d.hpp` only describes v1 and treats the atlas as external — both wrong empirically).
- `calibrate_vertical`: alpha-scans visible glyph rows over printable ASCII (`0x20-0x7E`) only. Rare extended-ASCII accented capitals (Ä Ö Ü etc.) reach 3-5 px higher than ordinary caps in the AgencyFB atlases — letting them drive the band metrics adds permanent blank headroom to every UI line.
- `.glyph` sidecar bridge in `gosFont::load`: when `dir/fname.glyph` exists alongside the `.d3f`, adopt only `font_line_skip_` and `max_advance_`. Sidecars carry retail's per-font line spacing without a hardcoded override table.
- Renderer-contract decouple at `gameos_graphics.cpp:2080-2089`: `gm.u`/`gm.v` used directly without `+ char_off_x/y`. Legacy `.glyph` loader gained a pre-fold step so `.bmp`+`.glyph` fallback renders pixel-identical under the new contract.
- Newline-glyph render guard: `drawText` per-character loop skips `c < 0x20` before glyph emission. D3F atlases ship a placeholder at index 10 that the legacy zero-width `.glyph` entry suppressed; without the guard, every `\n` rendered as a visible square in briefing/help text.
- Texture-state hygiene: text-draw block now saves/restores `Texture`, `Filter`, `TextureAddress`; forces `gos_TextureClamp` during draw (default wrap mode sampled across atlas seams under nearest filtering).
- Atlas upload: 8-bit alpha expanded to RGBA8 at load (fanned into all four channels for the `gos_text` shader's `.xxxx` swizzle), allocated via `gos_NewEmptyTexture`, uploaded via `glTexSubImage2D` against `gos_GetTextureGLId(handle)`.
- **Adds the small `gos_GetTextureGLId` helper** (3-line getter exposing `gosTexture::getTextureId`) to `gameos.hpp` + `gameos_graphics.cpp`. Loader is its only consumer in this PR.

### `5d484ae` — visual-bounds API for centered widgets

- New `gos_TextVisualBounds(DWORD* Width, int* Top, int* Bottom, ...)` API. Returns max line width (matches `gos_TextStringLength`) and signed pixel bounds of the actual ink relative to the text-position y-coordinate.
- Per-glyph ink bounds storage as runtime-only arrays on `gosGlyphInfo` (NOT in `gosGlyphMetrics` — that struct is blob-read from legacy `.glyph` files at `gos_load_glyphs`, extending it would break every sidecar font). `int8_t* ink_top_/ink_bot_` + separate `uint8_t* ink_valid_` flag (sentinel-on-`(0,0)` would conflict with single-row glyphs at offset 0).
- Three centering rewires, narrowly scoped:
  - `gui/abutton.cpp:176` — `aButton::render` button labels.
  - `code/controlgui.cpp:1511` — `ControlButton::render` HUD buttons.
  - `gui/alistbox.cpp:1306` — `aTextListItem::render` centering branch only (top-aligned `forceToTop` else branch left alone).
- `gos_TextStringLength()`, `aFont::height()`, and ~14 other callers untouched — line-skip semantics preserved for layout/stride consumers (afont word-wrap, controlgui help text, debugging overlay, float-help callouts, widget-stride consumers via cached `aFont::height()`).

### `70c3357` — drop residual +1 bias

The `+1` preserved at `aButton::render` and `ControlButton::render` was a compensation for the original line-skip-based centering bug. With visual-bounds centering on actual ink it shifts every centered label 1 px below true center. Internal `+1` in `(visTop + visBot + 1)/2` stays — that's the integer-division round-half-up idiom, not the legacy bias.

## Test plan

- [x] Build clean on MSVC 2022 Release x64 (only the documented `size_t→int` truncation warnings)
- [x] Visual verification on the head fork: Main Menu, Mission Selection (incl. Reacquisition red header via `aTextListItem`), Mission Briefing (incl. body text and bold-objective lines), Mech Bay (incl. STARSLAYER/Bushwacker slot labels), Pilot Ready (incl. ADD PILOT/REMOVE PILOT/LAUNCH), in-mission HUD button
- [x] Briefing newline-glyph squares gone
- [x] Multi-screen verification of the `+1` bias drop across all rewired sites
- [x] Regression-free on briefing body word-wrap, HUD objectives list, mech bay/pilot stat readouts (these all go through line-skip-semantics paths that this PR doesn't touch)

## Known residuals (out of scope here)

- Top-aligned screen headers (`MECH BAY`, `MISSION SELECTION`, etc.) sit a few px too high — different render path, not reached by the centering rewires. Tracked downstream.
- 1-bit atlas + nearest-filter at 2×+ display upscale produces harder edges than retail's near-1:1 render. Inherent to the format; not a loader bug.
- `arialnarrow8.d3f` mech-slot labels render lowercase that the legacy `.glyph` hid (zero-width entries) — labels now wider than the legacy port showed. Correct rendering; UI layout in `mcl_gn_deploymentteams.fit` is the real fix when revisited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)